### PR TITLE
Change redirect from shields to badgen

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![dependency](https://david-dm.org/styfle/packagephobia.svg)](https://david-dm.org/styfle/packagephobia)
 [![devDependency](https://david-dm.org/styfle/packagephobia/dev-status.svg)](https://david-dm.org/styfle/packagephobia?type=dev)
 [![travis](https://travis-ci.org/styfle/packagephobia.svg?branch=master)](https://travis-ci.org/styfle/packagephobia)
-[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
+[![code style: prettier](https://badgen.now.sh/badge/code%20style/prettier/ff69b4)](https://github.com/prettier/prettier)
 
 <a href="https://turnoff.us/geek/npm-install/"><img src="https://turnoff.us/image/en/npm-install.png" width=300 height=400 align="right" /></a>
 

--- a/now.json
+++ b/now.json
@@ -1,6 +1,7 @@
 {
     "name": "packagephobia",
     "alias": "packagephobia.now.sh",
+    "type": "docker",
     "env": {
         "NODE_ENV": "production",
         "REDIS_HOST": "@packagephobia-redis-host",

--- a/src/util/badge.ts
+++ b/src/util/badge.ts
@@ -4,5 +4,5 @@ export function getBadgeUrl(pkgSize: PkgSize) {
     const { installSize } = pkgSize;
     const { readable } = getReadableFileSize(installSize);
     const color = getHexColor(installSize);
-    return `https://badgen.now.sh/badge/install%20size/${readable}/${color}.svg`;
+    return `https://badgen.now.sh/badge/install%20size/${readable}/${color}`;
 }

--- a/src/util/badge.ts
+++ b/src/util/badge.ts
@@ -4,5 +4,5 @@ export function getBadgeUrl(pkgSize: PkgSize) {
     const { installSize } = pkgSize;
     const { readable } = getReadableFileSize(installSize);
     const color = getHexColor(installSize);
-    return `https://img.shields.io/badge/install%20size-${readable}-${color}.svg`;
+    return `https://badgen.now.sh/badge/install%20size/${readable}/${color}.svg`;
 }

--- a/src/util/npm-parser.ts
+++ b/src/util/npm-parser.ts
@@ -51,8 +51,9 @@ const oneHundredMb = 100 * megabyte;
 const fiveHundredMb = 500 * megabyte;
 
 /**
- * Colors came from here:
+ * Some colors are defined here:
  * https://github.com/badges/shields/blob/master/lib/colorscheme.json
+ * https://github.com/amio/badgen/blob/master/lib/color-presets.js
  */
 export const color = {
     brightgreen: '44CC11',


### PR DESCRIPTION
This new badge service should improve performance.

See [this tweet](https://twitter.com/amiocn/status/1017101016389435393) and [this tweet](https://twitter.com/amiocn/status/1017119844037058560) and [this tweet](https://twitter.com/styfle/status/1017127939626938371) for some of the differences.