### PR TITLE
Allow for custom npm registries via env var

### DIFF
--- a/src/util/backend/npm-stats.ts
+++ b/src/util/backend/npm-stats.ts
@@ -30,10 +30,20 @@ export async function calculatePackageSize(name: string, version: string, tmpDir
     const npm = join(process.env.PWD || '', 'node_modules', 'npm', 'bin', 'npm-cli.js');
     await execFile('mkdir', [tmpPackage], { cwd: tmpDir });
     await execFile(npm, ['init', '-y'], { cwd: pkgDir });
-    await execFile(npm, ['i', '--no-package-lock', '--no-audit', `${name}@${version}`], {
-        cwd: pkgDir,
-        timeout: 60000,
-    });
+    await execFile(
+        npm,
+        [
+            'i',
+            '--no-package-lock',
+            '--no-audit',
+            ...(process.env.NPM_REGISTRY_URL ? ['--registry', process.env.NPM_REGISTRY_URL] : []),
+            `${name}@${version}`,
+        ],
+        {
+            cwd: pkgDir,
+            timeout: 60000,
+        },
+    );
     const installSize = getDirSize(nodeModules);
     const publishSize = getDirSize(join(nodeModules, name));
     await execFile('rm', ['-rf', tmpPackage], { cwd: tmpDir });

--- a/src/util/npm-api.ts
+++ b/src/util/npm-api.ts
@@ -1,13 +1,15 @@
 import 'isomorphic-unfetch';
 import * as semver from 'semver';
 
+const { NPM_REGISTRY_URL = 'https://registry.npmjs.com' } = process.env;
+
 /**
  * Make an API call to npm to get package manifest details
  * @param name The npm package name
  */
 export async function fetchManifest(name: string) {
     const encodedPackage = escapePackageName(name);
-    const response = await fetch(`https://registry.npmjs.com/${encodedPackage}`);
+    const response = await fetch(`${NPM_REGISTRY_URL}/${encodedPackage}`);
     const manifest: NpmManifest = await response.json();
     if (response.status === 404 || !manifest || Object.keys(manifest).length === 0) {
         throw new Error('Package not found');


### PR DESCRIPTION
Fixes #137

- replace hardcoded npm registry url with one that defaults to the existing url and can be set via process.env.NPM_REGISTRY_URL.

So the only issue here is that the registry has to also be set for NPM, like in .npmrc or globally for the user on the machine. From a little digging I don't _think_ it can be set programmatically, aside from running a `npm config set` the same way the install is run. Currently I'm just using an .npmrc, when you're using your own registry you tend to have either that or the global config set up already anyway, but I'm open to suggestions to make it a little more opaque.