### PR TITLE
Fix string escape

### DIFF
--- a/src/util/npm-api.ts
+++ b/src/util/npm-api.ts
@@ -62,5 +62,5 @@ export function getVersionsForChart(allVersions: string[], version: string, coun
  * to be sent escaped.
  */
 function escapePackageName(name: string) {
-    return name.replace('/', '%2f');
+    return name.replace(/\//g, '%2f');
 }


### PR DESCRIPTION
Fixes a bug where a string input with two or more forward slashes would not be escaped properly

![image](https://user-images.githubusercontent.com/229881/45832632-719af400-bcd0-11e8-9c8e-e765cc2098a3.png)
