### PR TITLE
Add v2 api

### DIFF
--- a/src/components/BarGraph.tsx
+++ b/src/components/BarGraph.tsx
@@ -201,8 +201,8 @@ const getTooltipMessage = (r: PkgSize) => {
     if (r.disabled) {
         return `${r.version} | Unknown size | Click to build and find out!`;
     }
-    const install = getReadableFileSize(r.installSize).readable;
-    const publish = getReadableFileSize(r.publishSize).readable;
+    const install = getReadableFileSize(r.installSize).pretty;
+    const publish = getReadableFileSize(r.publishSize).pretty;
 
     return `${r.version} | Publish Size: ${publish} | Install Size: ${install}`;
 };

--- a/src/interfaces/types.d.ts
+++ b/src/interfaces/types.d.ts
@@ -7,7 +7,7 @@ interface PackageVersion {
 interface SizeWithUnit {
     size: string;
     unit: string;
-    readable: string;
+    pretty: string;
 }
 
 interface PkgSize {
@@ -18,9 +18,20 @@ interface PkgSize {
     disabled?: boolean;
 }
 
-interface ApiResponse {
+interface ApiResponseV1 {
     publishSize: number;
     installSize: number;
+}
+
+interface ApiResponseV2 {
+    publish: ApiResponseSize;
+    install: ApiResponseSize;
+}
+
+interface ApiResponseSize {
+    bytes: number;
+    pretty: string;
+    color: string;
 }
 
 interface ResultProps {

--- a/src/util/badge.ts
+++ b/src/util/badge.ts
@@ -2,7 +2,13 @@ import { getReadableFileSize, getHexColor } from './npm-parser';
 
 export function getBadgeUrl(pkgSize: PkgSize) {
     const { installSize } = pkgSize;
-    const { readable } = getReadableFileSize(installSize);
+    const { pretty: readable } = getReadableFileSize(installSize);
     const color = getHexColor(installSize);
     return `https://badgen.now.sh/badge/install%20size/${readable}/${color}`;
+}
+
+export function getApiResponseSize(bytes: number): ApiResponseSize {
+    const { pretty } = getReadableFileSize(bytes);
+    const color = '#' + getHexColor(bytes);
+    return { bytes, pretty, color };
 }

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -2,7 +2,8 @@ export const pages = {
     index: '/index',
     result: '/result',
     badge: '/badge',
-    api_json: '/api.json',
+    apiv1: '/api.json',
+    apiv2: '/v2/api.json',
     logo_svg: '/logo.svg',
     logo_png: '/logo.png',
 };

--- a/src/util/npm-parser.ts
+++ b/src/util/npm-parser.ts
@@ -40,7 +40,7 @@ export function getReadableFileSize(bytes: number): SizeWithUnit {
     const exponent = Math.min(Math.floor(Math.log10(bytes) / 3), UNITS.length - 1);
     const size = (bytes / Math.pow(KB, exponent)).toPrecision(3);
     const unit = UNITS[exponent];
-    return { size, unit, readable: `${size} ${unit}` };
+    return { size, unit, pretty: `${size} ${unit}` };
 }
 
 const oneHundredKb = 100 * KB;


### PR DESCRIPTION
This adds a new version of the API with some additional details.

## /api.json

```json
{
  "publishSize": 207337,
  "installSize": 1612366
}
```

## /v2/api.json

```json
{
  "name": "express",
  "version": "4.16.4",
  "publish": {
    "bytes": 207337,
    "pretty": "202 kB",
    "color": "#97CA00"
  },
  "install": {
    "bytes": 1612366,
    "pretty": "1.54 MB",
    "color": "#007EC6"
  }
}
```

This will provide more information for [badgen](https://github.com/amio/badgen-service) and for the [cli](https://github.com/chinanf-boy/packagephobia-cli).

/cc @amio @chinanf-boy

Fixes: #241