### PR TITLE
Use stable @now/node

### DIFF
--- a/now.json
+++ b/now.json
@@ -5,7 +5,7 @@
     "regions": ["all"],
     "builds": [
         { "src": "static/**", "use": "@now/static" },
-        { "src": "src/server.ts", "use": "@now/node@canary" }
+        { "src": "src/server.ts", "use": "@now/node" }
     ],
     "routes": [
         { "src": "/(.+svg|.+png|.+ico|robots.txt|browserconfig.xml)", "dest": "/static/$1" },


### PR DESCRIPTION
We no longer need to use the canary builder and so this changes `@now/node` to use stable.