### PR TITLE
Change regions to USA only

### DIFF
--- a/now.json
+++ b/now.json
@@ -2,7 +2,7 @@
     "name": "packagephobia",
     "alias": "packagephobia.now.sh",
     "version": 2,
-    "regions": ["all"],
+    "regions": ["sfo1", "pdx1", "cle1", "oma1", "iad1"],
     "builds": [
         { "src": "static/**", "use": "@now/static" },
         { "src": "src/server.ts", "use": "@now/node" }

--- a/now.json
+++ b/now.json
@@ -2,7 +2,7 @@
     "name": "packagephobia",
     "alias": "packagephobia.now.sh",
     "version": 2,
-    "regions": ["sfo1", "cle1", "oma1", "iad1"],
+    "regions": ["sfo1", "cle1", "pdx1", "iad1"],
     "builds": [
         { "src": "static/**", "use": "@now/static" },
         { "src": "src/server.ts", "use": "@now/node" }

--- a/now.json
+++ b/now.json
@@ -2,7 +2,7 @@
     "name": "packagephobia",
     "alias": "packagephobia.now.sh",
     "version": 2,
-    "regions": ["sfo1", "pdx1", "cle1", "oma1", "iad1"],
+    "regions": ["sfo1", "cle1", "oma1", "iad1"],
     "builds": [
         { "src": "static/**", "use": "@now/static" },
         { "src": "src/server.ts", "use": "@now/node" }


### PR DESCRIPTION
The DB (redis) is hosted in the USA so no reason to deploy to all regions.

It's also causing a bunch of concurrent connections.