### PR TITLE
Change .dockerignore to .nowignore

### DIFF
--- a/.nowignore
+++ b/.nowignore
@@ -1,6 +1,8 @@
 *
 !src
+!src/**
 !static
+!static/**
 !now.json
 !package-lock.json
 !package.json


### PR DESCRIPTION
Utilize the `.nowignore` file for faster deploys.

This wildcard syntax acts as an allowlist rather than an blocklist.