### PR TITLE
Revert "Bump npm from 6.10.0 to 6.10.1"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -277,9 +277,9 @@
       "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "npm": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-6.10.1.tgz",
-      "integrity": "sha512-ejR83c5aPTip5hPhziypqkJu06vb5tDIugCXx1c5+04RbMjtZeMA6BfsuGnV9EBdEwzKoaHkQ9sJWQAq+LjHYw==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-6.10.0.tgz",
+      "integrity": "sha512-pOMc81mT4fHXv/iMbw4T4GQVZzlzx/Vf5bta+JgMWVR+qqBeNI0mAbKrQ15vZf3eMJ+DaJj6+XgD7650JQs+rg==",
       "requires": {
         "JSONStream": "^1.3.5",
         "abbrev": "~1.1.1",
@@ -291,8 +291,8 @@
         "bluebird": "^3.5.5",
         "byte-size": "^5.0.1",
         "cacache": "^11.3.3",
-        "call-limit": "^1.1.1",
-        "chownr": "^1.1.2",
+        "call-limit": "~1.1.0",
+        "chownr": "^1.1.1",
         "ci-info": "^2.0.0",
         "cli-columns": "^3.1.2",
         "cli-table3": "^0.5.1",
@@ -309,25 +309,25 @@
         "fs-vacuum": "~1.2.10",
         "fs-write-stream-atomic": "~1.0.10",
         "gentle-fs": "^2.0.1",
-        "glob": "^7.1.4",
+        "glob": "^7.1.3",
         "graceful-fs": "^4.2.0",
         "has-unicode": "~2.0.1",
         "hosted-git-info": "^2.7.1",
         "iferr": "^1.0.2",
         "imurmurhash": "*",
         "inflight": "~1.0.6",
-        "inherits": "^2.0.4",
+        "inherits": "~2.0.3",
         "ini": "^1.3.5",
         "init-package-json": "^1.10.3",
         "is-cidr": "^3.0.0",
         "json-parse-better-errors": "^1.0.2",
         "lazy-property": "~1.0.0",
-        "libcipm": "^4.0.0",
-        "libnpm": "^3.0.0",
+        "libcipm": "^3.0.3",
+        "libnpm": "^2.0.1",
         "libnpmaccess": "*",
         "libnpmhook": "^5.0.2",
         "libnpmorg": "*",
-        "libnpmsearch": "^2.0.1",
+        "libnpmsearch": "*",
         "libnpmteam": "*",
         "libnpx": "^10.2.0",
         "lock-verify": "^2.1.0",
@@ -343,23 +343,23 @@
         "lodash.union": "~4.6.0",
         "lodash.uniq": "~4.5.0",
         "lodash.without": "~4.4.0",
-        "lru-cache": "^5.1.1",
+        "lru-cache": "^4.1.5",
         "meant": "~1.0.1",
         "mississippi": "^3.0.0",
         "mkdirp": "~0.5.1",
         "move-concurrently": "^1.0.1",
-        "node-gyp": "^5.0.2",
+        "node-gyp": "^3.8.0",
         "nopt": "~4.0.1",
         "normalize-package-data": "^2.5.0",
         "npm-audit-report": "^1.3.2",
         "npm-cache-filename": "~1.0.2",
         "npm-install-checks": "~3.0.0",
-        "npm-lifecycle": "^3.0.0",
+        "npm-lifecycle": "^2.1.0",
         "npm-package-arg": "^6.1.0",
         "npm-packlist": "^1.4.4",
         "npm-pick-manifest": "^2.2.3",
         "npm-profile": "*",
-        "npm-registry-fetch": "^3.9.1",
+        "npm-registry-fetch": "^3.9.0",
         "npm-user-validate": "~1.0.0",
         "npmlog": "~4.1.2",
         "once": "~1.4.0",
@@ -369,20 +369,20 @@
         "path-is-inside": "~1.0.2",
         "promise-inflight": "~1.0.1",
         "qrcode-terminal": "^0.12.0",
-        "query-string": "^6.8.1",
+        "query-string": "^6.4.0",
         "qw": "~1.0.1",
         "read": "~1.0.7",
         "read-cmd-shim": "~1.0.1",
         "read-installed": "~4.0.3",
         "read-package-json": "^2.0.13",
         "read-package-tree": "^5.3.1",
-        "readable-stream": "^3.4.0",
+        "readable-stream": "^3.3.0",
         "readdir-scoped-modules": "^1.1.0",
         "request": "^2.88.0",
         "retry": "^0.12.0",
         "rimraf": "^2.6.3",
         "safe-buffer": "^5.1.2",
-        "semver": "^5.7.0",
+        "semver": "^5.6.0",
         "sha": "^3.0.0",
         "slide": "~1.1.6",
         "sorted-object": "~2.0.1",
@@ -401,7 +401,7 @@
         "validate-npm-package-license": "^3.0.4",
         "validate-npm-package-name": "~3.0.0",
         "which": "^1.3.1",
-        "worker-farm": "^1.7.0",
+        "worker-farm": "^1.6.0",
         "write-file-atomic": "^2.4.3"
       },
       "dependencies": {
@@ -555,6 +555,13 @@
             "write-file-atomic": "^2.3.0"
           }
         },
+        "block-stream": {
+          "version": "0.0.9",
+          "bundled": true,
+          "requires": {
+            "inherits": "~2.0.0"
+          }
+        },
         "bluebird": {
           "version": "3.5.5",
           "bundled": true
@@ -627,11 +634,22 @@
                 "once": "^1.3.0",
                 "path-is-absolute": "^1.0.0"
               }
+            },
+            "lru-cache": {
+              "version": "5.1.1",
+              "bundled": true,
+              "requires": {
+                "yallist": "^3.0.2"
+              }
+            },
+            "yallist": {
+              "version": "3.0.3",
+              "bundled": true
             }
           }
         },
         "call-limit": {
-          "version": "1.1.1",
+          "version": "1.1.0",
           "bundled": true
         },
         "camelcase": {
@@ -656,7 +674,7 @@
           }
         },
         "chownr": {
-          "version": "1.1.2",
+          "version": "1.1.1",
           "bundled": true
         },
         "ci-info": {
@@ -864,20 +882,6 @@
             "lru-cache": "^4.0.1",
             "shebang-command": "^1.2.0",
             "which": "^1.2.9"
-          },
-          "dependencies": {
-            "lru-cache": {
-              "version": "4.1.5",
-              "bundled": true,
-              "requires": {
-                "pseudomap": "^1.0.2",
-                "yallist": "^2.1.2"
-              }
-            },
-            "yallist": {
-              "version": "2.1.2",
-              "bundled": true
-            }
           }
         },
         "crypto-random-string": {
@@ -1035,10 +1039,6 @@
           "requires": {
             "once": "^1.4.0"
           }
-        },
-        "env-paths": {
-          "version": "1.0.0",
-          "bundled": true
         },
         "err-code": {
           "version": "1.1.2",
@@ -1265,6 +1265,16 @@
           "version": "1.0.0",
           "bundled": true
         },
+        "fstream": {
+          "version": "1.0.12",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "inherits": "~2.0.0",
+            "mkdirp": ">=0.5 0",
+            "rimraf": "2"
+          }
+        },
         "function-bind": {
           "version": "1.1.1",
           "bundled": true
@@ -1345,7 +1355,7 @@
           }
         },
         "glob": {
-          "version": "7.1.4",
+          "version": "7.1.3",
           "bundled": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -1496,7 +1506,7 @@
           }
         },
         "inherits": {
-          "version": "2.0.4",
+          "version": "2.0.3",
           "bundled": true
         },
         "ini": {
@@ -1683,7 +1693,7 @@
           }
         },
         "libcipm": {
-          "version": "4.0.0",
+          "version": "3.0.3",
           "bundled": true,
           "requires": {
             "bin-links": "^1.1.2",
@@ -1694,7 +1704,7 @@
             "ini": "^1.3.5",
             "lock-verify": "^2.0.2",
             "mkdirp": "^0.5.1",
-            "npm-lifecycle": "^3.0.0",
+            "npm-lifecycle": "^2.0.3",
             "npm-logical-tree": "^1.2.1",
             "npm-package-arg": "^6.1.0",
             "pacote": "^9.1.0",
@@ -1704,7 +1714,7 @@
           }
         },
         "libnpm": {
-          "version": "3.0.0",
+          "version": "2.0.1",
           "bundled": true,
           "requires": {
             "bin-links": "^1.1.2",
@@ -1718,7 +1728,7 @@
             "libnpmsearch": "^2.0.0",
             "libnpmteam": "^1.0.1",
             "lock-verify": "^2.0.2",
-            "npm-lifecycle": "^3.0.0",
+            "npm-lifecycle": "^2.1.0",
             "npm-logical-tree": "^1.2.1",
             "npm-package-arg": "^6.1.0",
             "npm-profile": "^4.0.1",
@@ -1770,7 +1780,7 @@
               }
             },
             "p-limit": {
-              "version": "2.2.0",
+              "version": "2.1.0",
               "bundled": true,
               "requires": {
                 "p-try": "^2.0.0"
@@ -1784,7 +1794,7 @@
               }
             },
             "p-try": {
-              "version": "2.2.0",
+              "version": "2.0.0",
               "bundled": true
             }
           }
@@ -1831,7 +1841,7 @@
           }
         },
         "libnpmsearch": {
-          "version": "2.0.1",
+          "version": "2.0.0",
           "bundled": true,
           "requires": {
             "figgy-pudding": "^3.5.1",
@@ -1956,10 +1966,11 @@
           "bundled": true
         },
         "lru-cache": {
-          "version": "5.1.1",
+          "version": "4.1.5",
           "bundled": true,
           "requires": {
-            "yallist": "^3.0.2"
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
           }
         },
         "make-dir": {
@@ -1970,15 +1981,15 @@
           }
         },
         "make-fetch-happen": {
-          "version": "4.0.2",
+          "version": "4.0.1",
           "bundled": true,
           "requires": {
             "agentkeepalive": "^3.4.1",
-            "cacache": "^11.3.3",
+            "cacache": "^11.0.1",
             "http-cache-semantics": "^3.8.1",
             "http-proxy-agent": "^2.1.0",
             "https-proxy-agent": "^2.2.1",
-            "lru-cache": "^5.1.1",
+            "lru-cache": "^4.1.2",
             "mississippi": "^3.0.0",
             "node-fetch-npm": "^2.0.2",
             "promise-retry": "^1.1.1",
@@ -2103,19 +2114,20 @@
           }
         },
         "node-gyp": {
-          "version": "5.0.2",
+          "version": "3.8.0",
           "bundled": true,
           "requires": {
-            "env-paths": "^1.0.0",
+            "fstream": "^1.0.0",
             "glob": "^7.0.3",
             "graceful-fs": "^4.1.2",
             "mkdirp": "^0.5.0",
             "nopt": "2 || 3",
             "npmlog": "0 || 1 || 2 || 3 || 4",
+            "osenv": "0",
             "request": "^2.87.0",
             "rimraf": "2",
             "semver": "~5.3.0",
-            "tar": "^4.4.8",
+            "tar": "^2.0.0",
             "which": "1"
           },
           "dependencies": {
@@ -2129,6 +2141,15 @@
             "semver": {
               "version": "5.3.0",
               "bundled": true
+            },
+            "tar": {
+              "version": "2.2.2",
+              "bundled": true,
+              "requires": {
+                "block-stream": "*",
+                "fstream": "^1.0.12",
+                "inherits": "2"
+              }
             }
           }
         },
@@ -2183,12 +2204,12 @@
           }
         },
         "npm-lifecycle": {
-          "version": "3.0.0",
+          "version": "2.1.0",
           "bundled": true,
           "requires": {
             "byline": "^5.0.0",
-            "graceful-fs": "^4.1.15",
-            "node-gyp": "^5.0.2",
+            "graceful-fs": "^4.1.11",
+            "node-gyp": "^3.8.0",
             "resolve-from": "^4.0.0",
             "slide": "^1.1.6",
             "uid-number": "0.0.6",
@@ -2237,34 +2258,15 @@
           }
         },
         "npm-registry-fetch": {
-          "version": "3.9.1",
+          "version": "3.9.0",
           "bundled": true,
           "requires": {
             "JSONStream": "^1.3.4",
             "bluebird": "^3.5.1",
             "figgy-pudding": "^3.4.1",
-            "lru-cache": "^5.1.1",
-            "make-fetch-happen": "^4.0.2",
+            "lru-cache": "^4.1.3",
+            "make-fetch-happen": "^4.0.1",
             "npm-package-arg": "^6.1.0"
-          },
-          "dependencies": {
-            "make-fetch-happen": {
-              "version": "4.0.2",
-              "bundled": true,
-              "requires": {
-                "agentkeepalive": "^3.4.1",
-                "cacache": "^11.3.3",
-                "http-cache-semantics": "^3.8.1",
-                "http-proxy-agent": "^2.1.0",
-                "https-proxy-agent": "^2.2.1",
-                "lru-cache": "^5.1.1",
-                "mississippi": "^3.0.0",
-                "node-fetch-npm": "^2.0.2",
-                "promise-retry": "^1.1.1",
-                "socks-proxy-agent": "^4.0.0",
-                "ssri": "^6.0.0"
-              }
-            }
           }
         },
         "npm-run-path": {
@@ -2413,6 +2415,13 @@
             "which": "^1.3.1"
           },
           "dependencies": {
+            "lru-cache": {
+              "version": "5.1.1",
+              "bundled": true,
+              "requires": {
+                "yallist": "^3.0.2"
+              }
+            },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
@@ -2420,6 +2429,10 @@
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
               }
+            },
+            "yallist": {
+              "version": "3.0.3",
+              "bundled": true
             }
           }
         },
@@ -2578,11 +2591,10 @@
           "bundled": true
         },
         "query-string": {
-          "version": "6.8.1",
+          "version": "6.4.0",
           "bundled": true,
           "requires": {
             "decode-uri-component": "^0.2.0",
-            "split-on-first": "^1.0.0",
             "strict-uri-encode": "^2.0.0"
           }
         },
@@ -2654,7 +2666,7 @@
           }
         },
         "readable-stream": {
-          "version": "3.4.0",
+          "version": "3.3.0",
           "bundled": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -2758,7 +2770,7 @@
           "bundled": true
         },
         "semver": {
-          "version": "5.7.0",
+          "version": "5.6.0",
           "bundled": true
         },
         "semver-diff": {
@@ -2884,10 +2896,6 @@
         },
         "spdx-license-ids": {
           "version": "3.0.3",
-          "bundled": true
-        },
-        "split-on-first": {
-          "version": "1.1.0",
           "bundled": true
         },
         "sshpk": {
@@ -3267,7 +3275,7 @@
           }
         },
         "worker-farm": {
-          "version": "1.7.0",
+          "version": "1.6.0",
           "bundled": true,
           "requires": {
             "errno": "~0.1.7"
@@ -3318,7 +3326,7 @@
           "bundled": true
         },
         "yallist": {
-          "version": "3.0.3",
+          "version": "2.1.2",
           "bundled": true
         },
         "yargs": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "dependencies": {
     "node-fetch": "^2.6.0",
-    "npm": "^6.10.1",
+    "npm": "^6.10.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "redis": "^2.8.0",


### PR DESCRIPTION
Reverts #350

This broke npm install with the following:

```
running npm install in /tmp...
ERROR: ENOSPC: no space left on device, mkdir '/tmp/tmp-package0.1989069454247201'
```