### PR TITLE
Fix ENOSPC when package fails install

### DIFF
--- a/src/util/backend/npm-stats.ts
+++ b/src/util/backend/npm-stats.ts
@@ -34,10 +34,16 @@ export async function calculatePackageSize(name: string, version: string, tmpDir
     const nodeModules = join(pkgDir, 'node_modules');
     await mkdirAsync(pkgDir);
     await writeFileAsync(packageJson, packageString, 'utf8');
-    await npmInstall(pkgDir, cacheDir, name, version);
-    const installSize = getDirSize(nodeModules);
-    const publishSize = getDirSize(join(nodeModules, name));
-    await execFileAsync('rm', ['-rf', tmpPackage], { cwd: tmpDir });
-    const output: PkgSize = { name, version, publishSize, installSize };
+    let output: PkgSize;
+    try {
+        await npmInstall(pkgDir, cacheDir, name, version);
+        const installSize = getDirSize(nodeModules);
+        const publishSize = getDirSize(join(nodeModules, name));
+        output = { name, version, publishSize, installSize };
+    } catch (error) {
+        throw error;
+    } finally {
+        await execFileAsync('rm', ['-rf', tmpPackage], { cwd: tmpDir });
+    }
     return output;
 }

--- a/src/util/backend/npm-stats.ts
+++ b/src/util/backend/npm-stats.ts
@@ -31,7 +31,7 @@ export async function calculatePackageSize(name: string, version: string, tmpDir
 
     let t = setTimeout(async () => {
         await execFileAsync('rm', ['-rf', tmpPackage], { cwd: tmpDir });
-    }, 5 * 60 * 1000);
+    }, 2 * 60 * 1000);
 
     const pkgDir = join(tmpDir, tmpPackage);
     const cacheDir = join(tmpDir, 'npm-cache');


### PR DESCRIPTION
There was a bug where a large package like `protoss@4.0.3` would fill up the tmp storage and the never be deleted causing subsequent installs to break.