### PR TITLE
Hide octocat corner on mobile

### DIFF
--- a/src/components/OctocatCorner.tsx
+++ b/src/components/OctocatCorner.tsx
@@ -6,5 +6,5 @@ export default () => `<a href="https://github.com/styfle/packagephobia" class="g
         </svg>
     </a>
     <style>
-        .github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner {display:none}}
+        .github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:568px){.github-corner {display:none}}
     </style>`;

--- a/src/components/OctocatCorner.tsx
+++ b/src/components/OctocatCorner.tsx
@@ -6,5 +6,5 @@ export default () => `<a href="https://github.com/styfle/packagephobia" class="g
         </svg>
     </a>
     <style>
-        .github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+        .github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner {display:none}}
     </style>`;


### PR DESCRIPTION
This PR hides the octocat corner on smaller screens because it overlaps with the search button.

There is already a link to GitHub at the bottom footer so mobile can still get to the repo.

