### PR TITLE
Fix electron-download homedir()

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -10,9 +10,12 @@ import { getResultProps } from './page-props/results';
 import { getBadgeUrl, getApiResponseSize } from './util/badge';
 
 const { TMPDIR = '/tmp', GA_ID = '', PORT = 3107, NODE_ENV } = process.env;
+process.env.HOME = TMPDIR;
 const isProd = NODE_ENV === 'production';
 console.log('isProduction: ', isProd);
 console.log('TMPDIR: ', TMPDIR);
+console.log('HOME: ', process.env.HOME);
+
 
 export default async function handler(req: IncomingMessage, res: ServerResponse) {
     let { httpVersion, method, url } = req;


### PR DESCRIPTION
This assigns `HOME='/tmp'` so that `os.homedir()` returns the temporary directory which is the only writable directory.

This fixes `electron-download` and also `electron`.