### PR TITLE
Add cdn caching for html

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -45,8 +45,10 @@ export async function handler(req: IncomingMessage, res: ServerResponse) {
             res.setHeader('Cache-Control', cacheControl(isProd, cacheResult ? 7 : 0));
             res.end(JSON.stringify(result));
         } else {
+            const hasQuery = Object.keys(query).length > 0;
+            const isIndex = pathname === pages.index;
             res.setHeader('Content-Type', mimeType('*.html'));
-            res.setHeader('Cache-Control', cacheControl(isProd, 0));
+            res.setHeader('Cache-Control', cacheControl(isProd, hasQuery || isIndex ? 7 : 0));
             renderPage(res, pathname, query, TMPDIR, GA_ID);
         }
     } catch (e) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -46,7 +46,7 @@ export async function handler(req: IncomingMessage, res: ServerResponse) {
             res.end(JSON.stringify(result));
         } else {
             const isIndex = pathname === pages.index;
-            const hasVersion = typeof query.p === 'string' && parsePackageString(query.p) !== null;
+            const hasVersion = typeof query.p === 'string' && parsePackageString(query.p).version !== null;
             res.setHeader('Content-Type', mimeType('*.html'));
             res.setHeader('Cache-Control', cacheControl(isProd, isIndex || hasVersion ? 7 : 0));
             renderPage(res, pathname, query, TMPDIR, GA_ID);

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,10 +2,10 @@ import { IncomingMessage, ServerResponse } from 'http';
 import { parse } from 'url';
 import { mimeType, cacheControl } from './util/backend/lookup';
 import { renderPage } from './pages/_document';
-
 import { pages, versionUnknown } from './util/constants';
 import { getResultProps } from './page-props/results';
 import { getBadgeUrl, getApiResponseSize } from './util/badge';
+import { parsePackageString } from './util/npm-parser';
 
 const { TMPDIR = '/tmp', GA_ID = '', NODE_ENV } = process.env;
 process.env.HOME = TMPDIR;
@@ -45,10 +45,10 @@ export async function handler(req: IncomingMessage, res: ServerResponse) {
             res.setHeader('Cache-Control', cacheControl(isProd, cacheResult ? 7 : 0));
             res.end(JSON.stringify(result));
         } else {
-            const hasQuery = Object.keys(query).length > 0;
             const isIndex = pathname === pages.index;
+            const hasVersion = typeof query.p === 'string' && parsePackageString(query.p) !== null;
             res.setHeader('Content-Type', mimeType('*.html'));
-            res.setHeader('Cache-Control', cacheControl(isProd, hasQuery || isIndex ? 7 : 0));
+            res.setHeader('Cache-Control', cacheControl(isProd, isIndex || hasVersion ? 7 : 0));
             renderPage(res, pathname, query, TMPDIR, GA_ID);
         }
     } catch (e) {


### PR DESCRIPTION
This PR will cache pages that have a query string and also the home page since the HTML response will not change for subsequent requests.