### PR TITLE
Tweak GitHub Actions CI.

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,4 +1,4 @@
-name: Node CI
+name: Tests
 
 on:
   push:
@@ -8,23 +8,24 @@ on:
     - '!*'
   pull_request:
 
-jobs:
-  build:
+env:
+  CI: true
 
+jobs:
+  test:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
-        node-version: [10.x, 12.x]
+        node: [10.x, 12.x]
 
     steps:
     - uses: actions/checkout@v1
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js ${{ matrix.node }}
       uses: actions/setup-node@v1
       with:
-        node-version: ${{ matrix.node-version }}
-    - name: npm install, build, and test
-      run: |
-        npm install
-        npm run build --if-present
-        npm test
+        node-version: ${{ matrix.node }}
+    - run: npm ci
+    - run: npm build
+    - run: npm test

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 # Package Phobia
 
+[![tests](https://badgen.net/github/checks/styfle/packagephobia?label=tests&icon=github)](https://github.com/styfle/packagephobia/actions?workflow=Tests)
 [![dependency](https://badgen.net/david/dep/styfle/packagephobia)](https://david-dm.org/styfle/packagephobia)
 [![devDependency](https://badgen.net/david/dev/styfle/packagephobia)](https://david-dm.org/styfle/packagephobia?type=dev)
 [![lgtm](https://badgen.net/lgtm/grade/javascript/g/styfle/packagephobia)](https://lgtm.com/projects/g/styfle/packagephobia/)


### PR DESCRIPTION
* specify `CI: true`
* add `fail-fast: false`
* do `npm ci` instead of `npm install` which is faster and more appropriate
* split steps
* add README.md badge

We could probably add `npm audit` later if you want @styfle 