### PR TITLE
Compare the sizes of multiple packages and analyze package.json

### DIFF
--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -14,24 +14,26 @@ export default function Stats(props: Props) {
     );
 }
 
-type StatProp = SizeWithUnit & { label: string };
+type StatProp = SizeWithUnit & { label: string, scale?: number };
 
-function Stat(props: StatProp) {
+export function Stat(props: StatProp) {
+    const scale = props.scale || 1;
+
     const styleValue: React.CSSProperties = {
-        fontSize: '3rem',
+        fontSize: `${3 * scale}rem`,
         fontWeight: 'bold',
         color: '#212121',
     };
 
     const styleUnit: React.CSSProperties = {
-        fontSize: '2.4rem',
+        fontSize: `${2.4 * scale}rem`,
         color: '#666E78',
         fontWeight: 'bold',
         marginLeft: '4px',
     };
 
     const styleLabel: React.CSSProperties = {
-        fontSize: '1rem',
+        fontSize: `${1 * scale}rem`,
         color: '#666E78',
         textTransform: 'uppercase',
         letterSpacing: '2px',

--- a/src/interfaces/types.d.ts
+++ b/src/interfaces/types.d.ts
@@ -62,3 +62,9 @@ interface NpmManifest {
     time: { [version: string]: string };
     'dist-tags': { [tag: string]: string };
 }
+
+interface PackageJson {
+    dependencies: {
+        [key: string]: string;
+    }
+}

--- a/src/interfaces/types.d.ts
+++ b/src/interfaces/types.d.ts
@@ -43,6 +43,16 @@ interface ResultProps {
     isLatest: boolean;
 }
 
+interface ComparePackage {
+    pkgSize: PkgSize;
+    cacheResult: boolean;
+    isLatest: boolean;
+}
+
+interface CompareProps {
+    results: ComparePackage[];
+}
+
 interface ParsedUrlQuery {
     [key: string]: string | string[] | undefined;
 }

--- a/src/page-props/compare.ts
+++ b/src/page-props/compare.ts
@@ -1,0 +1,87 @@
+import { parsePackageString } from '../util/npm-parser';
+import { findOne, insert } from '../util/backend/db';
+import {
+    fetchManifest,
+    getAllDistTags,
+    getAllVersions,
+} from '../util/npm-api';
+import { calculatePackageSize } from '../util/backend/npm-stats';
+import { versionUnknown } from '../util/constants';
+
+async function getSize(name: string, version: string | null, force: boolean, tmpDir: string) {
+    let manifest: NpmManifest;
+    let cacheResult = true;
+    let isLatest = false;
+
+    try {
+        manifest = await fetchManifest(name);
+    } catch (e) {
+        console.error(`Package ${name} does not exist in npm`);
+        return packageNotFound(name);
+    }
+
+    const tagToVersion = getAllDistTags(manifest);
+    if (!version) {
+        version = tagToVersion['latest'];
+        isLatest = true;
+        cacheResult = false;
+    } else if (typeof tagToVersion[version] !== 'undefined') {
+        version = tagToVersion[version];
+        cacheResult = false;
+    }
+
+    const allVersions = getAllVersions(manifest);
+    if (!allVersions.includes(version)) {
+        console.error(`Version ${name}@${version} does not exist in npm`);
+        return packageNotFound(name);
+    }
+
+    let pkgSize = await findOne(name, version);
+    if (!pkgSize || force) {
+        console.log(`Cache miss for ${name}@${version} - running npm install in ${tmpDir}...`);
+        const start = new Date();
+        pkgSize = await calculatePackageSize(name, version, tmpDir);
+        const end = new Date();
+        const sec = (end.getTime() - start.getTime()) / 1000;
+        console.log(`Calculated size of ${name}@${version} in ${sec}s`);
+        insert(pkgSize);
+    }
+
+
+    const result: ComparePackage = {
+        pkgSize,
+        cacheResult,
+        isLatest,
+    };
+    return result;
+}
+
+export async function getCompareProps(query: ParsedUrlQuery, tmpDir: string) {
+    if (!query || typeof query.p !== 'string') {
+        throw new Error(`Unknown query string ${query}`);
+    }
+    const packages = query.p.split(',').map(parsePackageString);
+    const force = query.force === '1';
+
+    const resultPromises = packages.map(async ({ name, version }) => await getSize(name, version, force, tmpDir));
+    const results = await Promise.all(resultPromises);
+
+    return { results };
+}
+
+function packageNotFound(name: string) {
+    const pkgSize: PkgSize = {
+        name,
+        version: versionUnknown,
+        publishSize: 0,
+        installSize: 0,
+        disabled: true,
+    };
+    const result: ResultProps = {
+        pkgSize,
+        readings: [],
+        cacheResult: false,
+        isLatest: false,
+    };
+    return result;
+}

--- a/src/pages/_document.ts
+++ b/src/pages/_document.ts
@@ -126,6 +126,10 @@ export async function renderPage(
     );
     stream.on('end', () => {
         res.end(`</div>
+                <script>
+                    const input = document.querySelector('input[type=file]');
+                    input.onchange = () => input.form.submit();
+                </script>
                 <script>document.getElementById('spinner').style.display='none'</script>
                 <script type="text/javascript">
                     if (window.location.hostname === '${hostname}') {

--- a/src/pages/_document.ts
+++ b/src/pages/_document.ts
@@ -7,12 +7,14 @@ import ResultPage from '../pages/result';
 import ComparePage from '../pages/compare';
 import NotFoundPage from '../pages/404';
 import ServerErrorPage from '../pages/500';
+import ParseFailurePage from '../pages/parse-failure';
 
 const IndexFactory = createFactory(IndexPage);
 const ResultFactory = createFactory(ResultPage);
 const CompareFactory = createFactory(ComparePage);
 const NotFoundFactory = createFactory(NotFoundPage);
 const ServerErrorFactory = createFactory(ServerErrorPage);
+const ParseFailureFactory = createFactory(ParseFailurePage);
 
 import { getResultProps } from '../page-props/results';
 import { getCompareProps } from '../page-props/compare';
@@ -142,10 +144,13 @@ export async function renderPage(
 }
 
 async function routePage(pathname: string, query: ParsedUrlQuery, tmpDir: string) {
+    console.log(pathname);
     try {
         switch (pathname) {
             case pages.index:
                 return IndexFactory();
+            case pages.parseFailure:
+                return ParseFailureFactory();
             case pages.result:
                 return (query.p || '').includes(',')
                     ? CompareFactory(await getCompareProps(query, tmpDir))

--- a/src/pages/_document.ts
+++ b/src/pages/_document.ts
@@ -4,15 +4,18 @@ import { renderToNodeStream } from 'react-dom/server';
 
 import IndexPage from '../pages/index';
 import ResultPage from '../pages/result';
+import ComparePage from '../pages/compare';
 import NotFoundPage from '../pages/404';
 import ServerErrorPage from '../pages/500';
 
 const IndexFactory = createFactory(IndexPage);
 const ResultFactory = createFactory(ResultPage);
+const CompareFactory = createFactory(ComparePage);
 const NotFoundFactory = createFactory(NotFoundPage);
 const ServerErrorFactory = createFactory(ServerErrorPage);
 
 import { getResultProps } from '../page-props/results';
+import { getCompareProps } from '../page-props/compare';
 
 import { containerId, pages, hostname } from '../util/constants';
 import OctocatCorner from '../components/OctocatCorner';
@@ -144,7 +147,9 @@ async function routePage(pathname: string, query: ParsedUrlQuery, tmpDir: string
             case pages.index:
                 return IndexFactory();
             case pages.result:
-                return ResultFactory(await getResultProps(query, tmpDir));
+                return (query.p || '').includes(',')
+                    ? CompareFactory(await getCompareProps(query, tmpDir))
+                    : ResultFactory(await getResultProps(query, tmpDir));
             default:
                 return NotFoundFactory();
         }

--- a/src/pages/_document.ts
+++ b/src/pages/_document.ts
@@ -144,7 +144,6 @@ export async function renderPage(
 }
 
 async function routePage(pathname: string, query: ParsedUrlQuery, tmpDir: string) {
-    console.log(pathname);
     try {
         switch (pathname) {
             case pages.index:

--- a/src/pages/compare.tsx
+++ b/src/pages/compare.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { versionUnknown } from '../util/constants';
+import { getReadableFileSize } from '../util/npm-parser';
+import PageContainer from '../components/PageContainer';
+import Footer from '../components/Footer';
+import { getBadgeUrl } from '../util/badge';
+import { Stat } from '../components/Stats';
+import SearchBar from '../components/SearchBar';
+
+export default class ComparePage extends React.Component<CompareProps, {}> {
+    render() {
+        const { results } = this.props;
+
+        const resultsToPrint = results.map(({ pkgSize, isLatest }) => {
+            const { name, version, installSize, publishSize } = pkgSize;
+            const exists = version !== versionUnknown;
+            const install = getReadableFileSize(installSize);
+            const publish = getReadableFileSize(publishSize);
+            const pkgNameAndVersion = isLatest ? name : `${name}@${version}`;
+            const badgeUrl = getBadgeUrl(pkgSize, isLatest);
+            return {
+                exists,
+                install,
+                publish,
+                installSize,
+                pkgNameAndVersion,
+                badgeUrl,
+            }
+        });
+
+        return (
+            <>
+                <PageContainer>
+                    <SearchBar autoFocus={false} defaultValue={resultsToPrint.map(result => result.pkgNameAndVersion).join(',')} />
+                    <div style={{ maxWidth: '100%', 'overflow': 'scroll' }}>
+                        <table style={{ marginTop: '60px' }}>
+                            <tbody>
+                                {resultsToPrint.sort((a, b) => b.installSize - a.installSize).filter(result => result.exists).map((result, i) => (
+                                    <tr key={i}>
+                                        <td style={{ fontSize: '1.2em', paddingRight: '2em' }}>{result.pkgNameAndVersion}</td>
+                                        <td style={{ padding: '0 2em', textAlign: 'center' }}><Stat {...result.install} label="Install" scale={0.75} /></td>
+                                        <td style={{ padding: '0 2em', textAlign: 'center' }}><Stat {...result.publish} label="Publish" scale={0.75} /></td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+                </PageContainer>
+                <Footer />
+            </>
+        );
+    }
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -31,10 +31,9 @@ export default () => (
                 <label><span style={{ marginRight: '20px' }}>Or upload a package.json</span>
                     <input name="package.json" type="file" />
                 </label>
-                <button type="submit" value="submit">Submit</button>
+                <noscript><button type="submit" value="submit">Submit</button></noscript>
             </form>
         </PageContainer>
-
         <Footer />
     </>
 );

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -27,7 +27,7 @@ export default () => (
 
             <SearchBar autoFocus={true} />
 
-            <form style={{ marginTop: '60px' }} method="post" action="/compare" encType="multipart/form-data">
+            <form style={{ marginTop: '60px' }} method="post" action={pages.compare} encType="multipart/form-data">
                 <label><span style={{ marginRight: '20px' }}>Or upload a package.json</span>
                     <input name="package.json" type="file" />
                 </label>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -26,6 +26,13 @@ export default () => (
             </p>
 
             <SearchBar autoFocus={true} />
+
+            <form style={{ marginTop: '60px' }} method="post" action="/compare" encType="multipart/form-data">
+                <label><span style={{ marginRight: '20px' }}>Or upload a package.json</span>
+                    <input name="package.json" type="file" />
+                </label>
+                <button type="submit" value="submit">Submit</button>
+            </form>
         </PageContainer>
 
         <Footer />

--- a/src/pages/parse-failure.tsx
+++ b/src/pages/parse-failure.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import Footer from '../components/Footer';
+import { pages } from '../util/constants';
+
+const style: React.CSSProperties = {
+    height: '100vh',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+};
+
+export default () => (
+    <>
+        <div style={style}>
+            <h1>Failed to parse package.json</h1>
+            <p>Oops, the package.json you uploaded could not be parsed. Be sure you uploaded the right file.</p>
+            <p>
+                <a href={pages.index}>Go Home</a>
+            </p>
+        </div>
+        <Footer />
+    </>
+);

--- a/src/pages/parse-failure.tsx
+++ b/src/pages/parse-failure.tsx
@@ -19,8 +19,8 @@ export default () => (
             <p>
                 <a href={pages.index}>Go Home</a>
             </p>
+            <Image width={370} height={299} file="tumblebeasts/tbstand1.png" />
         </div>
-        <Image width={300} height={380} file="/tumblebeasts/tbstand1.png" />
         <Footer />
     </>
 );

--- a/src/pages/parse-failure.tsx
+++ b/src/pages/parse-failure.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Image from '../components/Image';
 import Footer from '../components/Footer';
 import { pages } from '../util/constants';
 
@@ -19,6 +20,7 @@ export default () => (
                 <a href={pages.index}>Go Home</a>
             </p>
         </div>
+        <Image width={300} height={380} file="/tumblebeasts/tbstand1.png" />
         <Footer />
     </>
 );

--- a/src/server.ts
+++ b/src/server.ts
@@ -64,10 +64,8 @@ export async function handler(req: IncomingMessage, res: ServerResponse) {
                 }
                 const queryString = Object.entries(packageData.dependencies).map(([pkg, version]) => {
                     let queryPart = pkg;
-                    if (version !== '*') {
-                        queryPart += `@${semver.coerce(String(version))}`;
-                    }
-                    return queryPart;
+                    const versionPart = version === '*' ? 'latest' : semver.coerce(String(version));
+                    return `${queryPart}@${versionPart}`;
                 });
                 res.writeHead(302, { Location: `/result?p=${queryString}` });
                 return res.end();

--- a/src/server.ts
+++ b/src/server.ts
@@ -51,16 +51,16 @@ export async function handler(req: IncomingMessage, res: ServerResponse) {
             req.on('end', () => {
                 const [packageString] = data.toString().match(/{[\s\S]+}/) || [];
                 if (!packageString) {
-                    return renderPage(res, '/parse-failure', query, TMPDIR, GA_ID);
+                    return renderPage(res, pages.parseFailure, query, TMPDIR, GA_ID);
                 }
-                let packageData;
+                let packageData: PackageJson;
                 try {
                     packageData = JSON.parse(packageString);
                 } catch (e) {
-                    return renderPage(res, '/parse-failure', query, TMPDIR, GA_ID);
+                    return renderPage(res, pages.parseFailure, query, TMPDIR, GA_ID);
                 }
                 if (!packageData.dependencies) {
-                    return renderPage(res, '/parse-failure', query, TMPDIR, GA_ID);
+                    return renderPage(res, pages.parseFailure, query, TMPDIR, GA_ID);
                 }
                 const queryString = Object.entries(packageData.dependencies).map(([pkg, version]) => {
                     let queryPart = pkg;

--- a/src/server.ts
+++ b/src/server.ts
@@ -63,9 +63,8 @@ export async function handler(req: IncomingMessage, res: ServerResponse) {
                     return renderPage(res, pages.parseFailure, query, TMPDIR, GA_ID);
                 }
                 const queryString = Object.entries(packageData.dependencies).map(([pkg, version]) => {
-                    let queryPart = pkg;
                     const versionPart = version === '*' ? 'latest' : semver.coerce(String(version));
-                    return `${queryPart}@${versionPart}`;
+                    return `${pkg}@${versionPart}`;
                 });
                 res.writeHead(302, { Location: `/result?p=${queryString}` });
                 return res.end();

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -1,7 +1,7 @@
 export const pages = {
     index: '/index',
     result: '/result',
-    compare: '/compare',
+    compare: '/scan-results',
     parseFailure: '/parse-failure',
     badge: '/badge',
     apiv1: '/api.json',

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -2,6 +2,7 @@ export const pages = {
     index: '/index',
     result: '/result',
     compare: '/compare',
+    parseFailure: '/parse-failure',
     badge: '/badge',
     apiv1: '/api.json',
     apiv2: '/v2/api.json',

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -1,6 +1,7 @@
 export const pages = {
     index: '/index',
     result: '/result',
+    compare: '/compare',
     badge: '/badge',
     apiv1: '/api.json',
     apiv2: '/v2/api.json',


### PR DESCRIPTION
This PR adds package comparison using commas in the search bar and the ability to upload a `package.json` from the index page. Fixes #133

This is very "minimum viable implementation" — there's definitely room for improvement, especially on the frontend of the comparison page, but I wanted to put this out there as a possibility for the implementation of the core functionality. Happy to chat about and reconsider any of the design decisions here!