### PR TITLE
Add publish date

### DIFF
--- a/src/components/BarGraph.tsx
+++ b/src/components/BarGraph.tsx
@@ -203,6 +203,6 @@ const getTooltipMessage = (r: PkgSize) => {
     }
     const install = getReadableFileSize(r.installSize).pretty;
     const publish = getReadableFileSize(r.publishSize).pretty;
-
-    return `${r.version} | Publish Size: ${publish} | Install Size: ${install} | Publish Date: ${r.publishDate}`;
+    const suffix =  r.publishDate ? ` | Publish Date: ${r.publishDate}` : '';
+    return `${r.version} | Publish Size: ${publish} | Install Size: ${install}${suffix}`;
 };

--- a/src/components/BarGraph.tsx
+++ b/src/components/BarGraph.tsx
@@ -203,6 +203,6 @@ const getTooltipMessage = (r: PkgSize) => {
     }
     const install = getReadableFileSize(r.installSize).pretty;
     const publish = getReadableFileSize(r.publishSize).pretty;
-    const suffix =  r.publishDate ? ` | Publish Date: ${r.publishDate}` : '';
+    const suffix = r.publishDate ? ` | Publish Date: ${r.publishDate}` : '';
     return `${r.version} | Publish Size: ${publish} | Install Size: ${install}${suffix}`;
 };

--- a/src/components/BarGraph.tsx
+++ b/src/components/BarGraph.tsx
@@ -203,6 +203,6 @@ const getTooltipMessage = (r: PkgSize) => {
     }
     const install = getReadableFileSize(r.installSize).pretty;
     const publish = getReadableFileSize(r.publishSize).pretty;
-    const suffix = r.publishDate ? ` | Publish Date: ${r.publishDate}` : '';
+    const suffix = r.publishDate ? ` | Publish Date: ${r.publishDate.split('T')[0]}` : '';
     return `${r.version} | Publish Size: ${publish} | Install Size: ${install}${suffix}`;
 };

--- a/src/components/BarGraph.tsx
+++ b/src/components/BarGraph.tsx
@@ -204,5 +204,5 @@ const getTooltipMessage = (r: PkgSize) => {
     const install = getReadableFileSize(r.installSize).pretty;
     const publish = getReadableFileSize(r.publishSize).pretty;
 
-    return `${r.version} | Publish Size: ${publish} | Install Size: ${install}`;
+    return `${r.version} | Publish Size: ${publish} | Install Size: ${install} | Publish Date: ${r.publishDate}`;
 };

--- a/src/interfaces/types.d.ts
+++ b/src/interfaces/types.d.ts
@@ -13,6 +13,7 @@ interface SizeWithUnit {
 interface PkgSize {
     name: string;
     version: string;
+    publishDate: string;
     publishSize: number;
     installSize: number;
     disabled?: boolean;

--- a/src/page-props/common.ts
+++ b/src/page-props/common.ts
@@ -62,7 +62,7 @@ function packageNotFound(name: string) {
     const pkgSize: PkgSize = {
         name,
         version: versionUnknown,
-        publishDate: new Date().toUTCString(),
+        publishDate: '',
         publishSize: 0,
         installSize: 0,
         disabled: true,

--- a/src/page-props/results.ts
+++ b/src/page-props/results.ts
@@ -1,6 +1,6 @@
 import { parsePackageString, isFullRelease } from '../util/npm-parser';
 import { findAll } from '../util/backend/db';
-import { getVersionsForChart } from '../util/npm-api';
+import { getVersionsForChart, getPublishDate } from '../util/npm-api';
 import { getPkgDetails } from './common';
 
 export async function getResultProps(query: ParsedUrlQuery, tmpDir: string): Promise<ResultProps> {
@@ -9,7 +9,7 @@ export async function getResultProps(query: ParsedUrlQuery, tmpDir: string): Pro
     }
     const parsed = parsePackageString(query.p);
     const force = query.force === '1';
-    const { pkgSize, allVersions, cacheResult, isLatest } = await getPkgDetails(
+    const { pkgSize, allVersions, cacheResult, isLatest, manifest } = await getPkgDetails(
         parsed.name,
         parsed.version,
         force,
@@ -32,6 +32,7 @@ export async function getResultProps(query: ParsedUrlQuery, tmpDir: string): Pro
             return {
                 name: name,
                 version: v,
+                publishDate: getPublishDate(manifest, v),
                 publishSize: 0,
                 installSize: 0,
                 disabled: true,

--- a/src/util/backend/npm-stats.ts
+++ b/src/util/backend/npm-stats.ts
@@ -26,7 +26,12 @@ export function getDirSize(root: string, seen = new Set()): number {
         .reduce((acc, num) => acc + num, 0);
 }
 
-export async function calculatePackageSize(name: string, version: string, tmpDir: string) {
+export async function calculatePackageSize(
+    name: string,
+    version: string,
+    publishDate: string,
+    tmpDir: string,
+) {
     const tmpPackage = 'tmp-package' + Math.random();
 
     let t = setTimeout(async () => {
@@ -42,7 +47,7 @@ export async function calculatePackageSize(name: string, version: string, tmpDir
     await npmInstall(pkgDir, cacheDir, name, version);
     const installSize = getDirSize(nodeModules);
     const publishSize = getDirSize(join(nodeModules, name));
-    const output: PkgSize = { name, version, publishSize, installSize };
+    const output: PkgSize = { name, version, publishDate, publishSize, installSize };
     clearTimeout(t);
     await execFileAsync('rm', ['-rf', tmpPackage], { cwd: tmpDir });
 

--- a/src/util/npm-api.ts
+++ b/src/util/npm-api.ts
@@ -60,6 +60,13 @@ export function getVersionsForChart(allVersions: string[], version: string, coun
 }
 
 /**
+ * Get the npm publish date of a specific version
+ */
+export function getPublishDate(manifest: NpmManifest | null, version: string) {
+    return manifest ? manifest.time[version] : '';
+}
+
+/**
  * Escape an npm package name.
  * The registry expects the slashes in the (scoped) package names
  * to be sent escaped.

--- a/test/npm-api-test.ts
+++ b/test/npm-api-test.ts
@@ -14,7 +14,20 @@ const manifest = {
         '1.3.0': '',
         '2.0.0': '',
     },
-    time: {},
+    time: {
+        modified: '2019-01-01T16:01:12.408Z',
+        created: '2015-07-23T06:26:33.784Z',
+        '1.0.0': '2017-10-14T22:05:10.599Z',
+        '1.0.1': '2017-11-13T00:19:38.495Z',
+        '1.0.2': '2017-12-02T02:56:22.595Z',
+        '1.0.3': '2017-12-12T15:38:31.824Z',
+        '1.1.0': '2018-03-12T00:02:12.562Z',
+        '1.2.0': '2018-04-03T00:18:23.503Z',
+        '1.3.0-alpha': '2018-04-04T00:11:19.000Z',
+        '1.3.0-beta': '2018-05-05T00:21:45.000Z',
+        '1.3.0': '2018-07-06T00:19:51.000Z',
+        '2.0.0': '2018-07-11T00:24:16.000Z',
+    },
     'dist-tags': { latest: '2.0.0' },
 };
 
@@ -100,4 +113,16 @@ test('getVersionsForChart with count larger than allVersions', t => {
     t.plan(1);
     const actual = npmapi.getVersionsForChart(allVersions, '1.3.0-beta', 30);
     t.deepEqual(actual, allVersions);
+});
+
+test('getPublishDate should get date for specific version', t => {
+    t.plan(1);
+    const actual = npmapi.getPublishDate(manifest, '1.0.0');
+    t.deepEqual(actual, '2017-10-14T22:05:10.599Z');
+});
+
+test('getPublishDate should return empty string for null manifest', t => {
+    t.plan(1);
+    const actual = npmapi.getPublishDate(null, '1.0.0');
+    t.deepEqual(actual, '');
 });


### PR DESCRIPTION
Fixes #442

@XhmikosR Since package versions are cached in redis, the date will be missing for existing packages. Is this feature worth invalidating all the data we already have on each version?