### PR TITLE
Update compare.tsx

### DIFF
--- a/src/pages/compare.tsx
+++ b/src/pages/compare.tsx
@@ -37,7 +37,7 @@ export default class ComparePage extends React.Component<CompareProps, {}> {
                             .map(result => result.pkgNameAndVersion)
                             .join(',')}
                     />
-                    <div style={{ maxWidth: '100%', overflow: 'scroll' }}>
+                    <div style={{ maxWidth: '100%', overflow: 'auto' }}>
                         <table style={{ marginTop: '60px' }}>
                             <tbody>
                                 {resultsToPrint


### PR DESCRIPTION
Switch to `overflow: auto` so that the scrollbars are only shown when needed

Not sure if there are more cases like this; if so this should be applied there too.