### PR TITLE
Use local link instead of badgen.net

### DIFF
--- a/src/pages/_document.ts
+++ b/src/pages/_document.ts
@@ -110,11 +110,6 @@ export async function renderPage(
                 <title>${title}</title>
                 <meta name="description" content="${description}">
                 <style>${css}</style>
-                ${
-                    pathname === pages.result
-                        ? '<link rel="preconnect" href="https://badgen.net">'
-                        : ''
-                }
                 <link rel="apple-touch-icon" href="/apple-touch-icon.png" sizes="180x180">
                 <link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png">
                 <link rel="icon" href="/favicon-16x16.png" sizes="16x16" type="image/png">

--- a/src/util/badge.ts
+++ b/src/util/badge.ts
@@ -4,8 +4,8 @@ import { pages, hostname } from '../util/constants';
 export function getBadgeUrl(pkgSize: PkgSize, isLatest: boolean) {
     const { name, version } = pkgSize;
     return isLatest
-        ? `https://badgen.net/packagephobia/install/${name}`
-        : `https://badgen.net/packagephobia/install/${name}@${version}`;
+        ? `https://${hostname}${pages.badge}?p=${name}`
+        : `https://${hostname}${pages.badge}?p=${name}@${version}`;
 }
 
 export function getBadgeMarkdown(pkgNameAndVersion: string) {


### PR DESCRIPTION
I don't recall why the badge was generated via badgen.net but the markdown snippet was using the local badge url. This PR changes both to use the local badge url.