### PR TITLE
Add packagephobia.com domain name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="https://packagephobia.now.sh/logo.svg" width=40 height=40 align="left" />
+<img src="https://packagephobia.com/logo.svg" width=40 height=40 align="left" />
 
 # Package Phobia
 
@@ -28,25 +28,25 @@ This is useful for inspecting potential `dependencies` or `devDependencies` with
 
 Results are saved so the first person might wait a bit to view package size, but everyone else gets to see the results instantly!
 
-## [Demo](https://packagephobia.now.sh)
+## [Demo](https://packagephobia.com)
 
 A good use case might be comparing test runners, web frameworks, or even bundlers. Click one of the links below to see Package Phobia in action!
 
-- Test Harnesses: [tap](https://packagephobia.now.sh/result?p=tap) vs [tape](https://packagephobia.now.sh/result?p=tape)
-- Web Frameworks: [express](https://packagephobia.now.sh/result?p=express) vs [micro](https://packagephobia.now.sh/result?p=micro)
-- JavaScript Bundlers: [webpack](https://packagephobia.now.sh/result?p=webpack) vs [rollup](https://packagephobia.now.sh/result?p=rollup)
-- Task Runners: [grunt](https://packagephobia.now.sh/result?p=grunt) vs [gulp](https://packagephobia.now.sh/result?p=gulp)
-- HTTP Requests: [request](https://packagephobia.now.sh/result?p=request) vs [node-fetch](https://packagephobia.now.sh/result?p=node-fetch)
-- Glob Patterns: [glob](https://packagephobia.now.sh/result?p=glob) vs [tiny-glob](https://packagephobia.now.sh/result?p=tiny-glob)
-- Arguments: [yargs](https://packagephobia.now.sh/result?p=yargs) vs [arg](https://packagephobia.now.sh/result?p=arg)
-- Site Generators: [gatsby](https://packagephobia.now.sh/result?p=gatsby) vs [hexo](https://packagephobia.now.sh/result?p=hexo)
-- Type Checkers: [typescript](https://packagephobia.now.sh/result?p=typescript) vs [flow-bin](https://packagephobia.now.sh/result?p=flow-bin)
-- Linters: [eslint](https://packagephobia.now.sh/result?p=eslint) vs [jslint](https://packagephobia.now.sh/result?p=jslint)
-- Color Formatters: [chalk](https://packagephobia.now.sh/result?p=chalk) vs [colorette](https://packagephobia.now.sh/result?p=colorette)
-- Command Line Interfaces: [@angular/cli](https://packagephobia.now.sh/result?p=%40angular%2Fcli) vs [@babel/cli](https://packagephobia.now.sh/result?p=%40babel%2Fcli)
-- Desktop Frameworks: [nw](https://packagephobia.now.sh/result?p=nw) vs [electron](https://packagephobia.now.sh/result?p=electron)
-- Headless Browsers: [puppeteer](https://packagephobia.now.sh/result?p=puppeteer) vs [chrome-aws-lambda](https://packagephobia.now.sh/result?p=chrome-aws-lambda)
-- Package Managers: [npm](https://packagephobia.now.sh/result?p=npm) vs [yarn](https://packagephobia.now.sh/result?p=yarn)
+- Test Harnesses: [tap](https://packagephobia.com/result?p=tap) vs [tape](https://packagephobia.com/result?p=tape)
+- Web Frameworks: [express](https://packagephobia.com/result?p=express) vs [micro](https://packagephobia.com/result?p=micro)
+- JavaScript Bundlers: [webpack](https://packagephobia.com/result?p=webpack) vs [rollup](https://packagephobia.com/result?p=rollup)
+- Task Runners: [grunt](https://packagephobia.com/result?p=grunt) vs [gulp](https://packagephobia.com/result?p=gulp)
+- HTTP Requests: [request](https://packagephobia.com/result?p=request) vs [node-fetch](https://packagephobia.com/result?p=node-fetch)
+- Glob Patterns: [glob](https://packagephobia.com/result?p=glob) vs [tiny-glob](https://packagephobia.com/result?p=tiny-glob)
+- Arguments: [yargs](https://packagephobia.com/result?p=yargs) vs [arg](https://packagephobia.com/result?p=arg)
+- Site Generators: [gatsby](https://packagephobia.com/result?p=gatsby) vs [hexo](https://packagephobia.com/result?p=hexo)
+- Type Checkers: [typescript](https://packagephobia.com/result?p=typescript) vs [flow-bin](https://packagephobia.com/result?p=flow-bin)
+- Linters: [eslint](https://packagephobia.com/result?p=eslint) vs [jslint](https://packagephobia.com/result?p=jslint)
+- Color Formatters: [chalk](https://packagephobia.com/result?p=chalk) vs [colorette](https://packagephobia.com/result?p=colorette)
+- Command Line Interfaces: [@angular/cli](https://packagephobia.com/result?p=%40angular%2Fcli) vs [@babel/cli](https://packagephobia.com/result?p=%40babel%2Fcli)
+- Desktop Frameworks: [nw](https://packagephobia.com/result?p=nw) vs [electron](https://packagephobia.com/result?p=electron)
+- Headless Browsers: [puppeteer](https://packagephobia.com/result?p=puppeteer) vs [chrome-aws-lambda](https://packagephobia.com/result?p=chrome-aws-lambda)
+- Package Managers: [npm](https://packagephobia.com/result?p=npm) vs [yarn](https://packagephobia.com/result?p=yarn)
 
 ## Prior Art
 
@@ -54,7 +54,7 @@ Package Phobia is inspired by [Bundle Phobia](https://github.com/pastelsky/bundl
 
 ## How is this different?
 
-- [Package Phobia](https://packagephobia.now.sh) **THIS TOOL** web app that reports the install size of a package over time.
+- [Package Phobia](https://packagephobia.com) **THIS TOOL** web app that reports the install size of a package over time.
 - [Bundle Phobia](https://bundlephobia.com) web app that reports the size after webpack bundles the package over time.
 - [Cost Of Modules](https://github.com/siddharthkp/cost-of-modules) cli that reports the size of your currently installed packages.
 - [Badge Size](https://github.com/ngryman/badge-size) badge service that reports the gzip size of a single file from a package as svg.

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -92,7 +92,7 @@ export async function renderPage(
     pathname: string,
     query: ParsedUrlQuery,
     tmpDir: string,
-    gaId: string,
+    gaId = '',
 ) {
     res.statusCode = getStatusCode(pathname);
     res.write(`<!DOCTYPE html>
@@ -135,7 +135,7 @@ export async function renderPage(
                 </script>
                 <script>document.getElementById('spinner').style.display='none'</script>
                 <script>
-                    if (window.location.hostname === '${hostname}') {
+                    if ('${gaId}') {
                         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
                         (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
                         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,7 +18,7 @@ console.log('HOME: ', process.env.HOME);
 
 export async function handler(req: IncomingMessage, res: ServerResponse) {
     let { httpVersion, method, url, headers } = req;
-    console.log(`${httpVersion} ${method} ${url}`);
+    console.log(`${headers.host} ${httpVersion} ${method} ${url}`);
     let { pathname = '/', query = {} } = parse(url || '', true);
     if (!pathname || pathname === '/') {
         pathname = pages.index;

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,8 +17,8 @@ console.log('TMPDIR: ', TMPDIR);
 console.log('HOME: ', process.env.HOME);
 
 export async function handler(req: IncomingMessage, res: ServerResponse) {
-    let { httpVersion, method, url, headers } = req;
-    console.log(`${headers.host} ${httpVersion} ${method} ${url}`);
+    let { method, url, headers } = req;
+    console.log(`${method} ${headers.host}${url}`);
     let { pathname = '/', query = {} } = parse(url || '', true);
     if (!pathname || pathname === '/') {
         pathname = pages.index;
@@ -66,7 +66,7 @@ export async function handler(req: IncomingMessage, res: ServerResponse) {
                 }
             });
         } else if (headers.host === oldHostname) {
-            res.writeHead(302, { Location: `https://${hostname}` });
+            res.writeHead(302, { Location: `https://${hostname}${url}` });
         } else {
             const isIndex = pathname === pages.index;
             const hasVersion =

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,7 +2,7 @@ import { IncomingMessage, ServerResponse } from 'http';
 import { parse } from 'url';
 import { mimeType, cacheControl } from './util/backend/lookup';
 import { renderPage } from './pages/_document';
-import { pages, versionUnknown } from './util/constants';
+import { pages, versionUnknown, hostname, oldHostname } from './util/constants';
 import { getResultProps } from './page-props/results';
 import { getBadgeUrl, getApiResponseSize } from './util/badge';
 import { parsePackageString } from './util/npm-parser';
@@ -17,7 +17,7 @@ console.log('TMPDIR: ', TMPDIR);
 console.log('HOME: ', process.env.HOME);
 
 export async function handler(req: IncomingMessage, res: ServerResponse) {
-    let { httpVersion, method, url } = req;
+    let { httpVersion, method, url, headers } = req;
     console.log(`${httpVersion} ${method} ${url}`);
     let { pathname = '/', query = {} } = parse(url || '', true);
     if (!pathname || pathname === '/') {
@@ -65,6 +65,8 @@ export async function handler(req: IncomingMessage, res: ServerResponse) {
                     return renderPage(res, pages.parseFailure, query, TMPDIR, GA_ID);
                 }
             });
+        } else if (headers.host === oldHostname) {
+            res.writeHead(302, { Location: `https://${hostname}` });
         } else {
             const isIndex = pathname === pages.index;
             const hasVersion =

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -11,4 +11,5 @@ export const pages = {
 };
 export const containerId = 'app-container';
 export const versionUnknown = 'unknown';
-export const hostname = 'packagephobia.now.sh';
+export const hostname = 'packagephobia.com';
+export const oldHostname = 'packagephobia.now.sh';


### PR DESCRIPTION
After 2+ years, it is time for a proper dot com https://packagephobia.com

We'll redirect https://packagephobia.now.sh to https://packagephobia.com for any existing links out there.