### PR TITLE
Change memory usage and region

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
-    "regions": [ "sfo1", "cle1", "pdx1", "iad1" ],
+    "regions": [ "iad1" ],
     "functions": {
         "api/**": {
             "memory": 1024

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
     "regions": [ "sfo1", "cle1", "pdx1", "iad1" ],
     "functions": {
         "api/**": {
-            "memory": 3008
+            "memory": 1024
         }
     },
     "headers": [{


### PR DESCRIPTION
We don't need 3GB in most cases, 1GB should do the trick.

Also redis is hosted in iad1 so we should only run the function there to reduce latency.