### PR TITLE
Add meta title and description from npm

### DIFF
--- a/src/interfaces/types.d.ts
+++ b/src/interfaces/types.d.ts
@@ -62,6 +62,8 @@ interface ParsedUrlQuery {
 }
 
 interface NpmManifest {
+    name: string;
+    description: string;
     versions: { [version: string]: any };
     time: { [version: string]: string };
     'dist-tags': {

--- a/src/page-props/common.ts
+++ b/src/page-props/common.ts
@@ -1,22 +1,20 @@
 import { findOne, insert } from '../util/backend/db';
-import { fetchManifest, getAllDistTags, getAllVersions, getPublishDate } from '../util/npm-api';
+import { getAllDistTags, getAllVersions, getPublishDate } from '../util/npm-api';
 import { calculatePackageSize } from '../util/backend/npm-stats';
 import { versionUnknown } from '../util/constants';
 
 export async function getPkgDetails(
+    manifest: NpmManifest | null,
     name: string,
     version: string | null,
     force: boolean,
     tmpDir: string,
 ) {
-    let manifest: NpmManifest;
     let cacheResult = true;
     let isLatest = false;
 
-    try {
-        manifest = await fetchManifest(name);
-    } catch (e) {
-        console.error(`Package ${name} does not exist in npm`);
+    if (!manifest) {
+        console.error(`Package "${name}" does not exist in npm`);
         return packageNotFound(name);
     }
 
@@ -53,7 +51,6 @@ export async function getPkgDetails(
         cacheResult,
         isLatest,
         allVersions,
-        manifest,
     };
     return result;
 }

--- a/src/page-props/compare.ts
+++ b/src/page-props/compare.ts
@@ -1,3 +1,4 @@
+import { fetchManifest } from '../util/npm-api';
 import { parsePackageString } from '../util/npm-parser';
 import { getPkgDetails } from './common';
 
@@ -8,9 +9,10 @@ export async function getCompareProps(query: ParsedUrlQuery, tmpDir: string) {
     const packages = query.p.split(',').map(parsePackageString);
     const force = query.force === '1';
 
-    const promises = packages.map(({ name, version }) =>
-        getPkgDetails(name, version, force, tmpDir),
-    );
+    const promises = packages.map(async ({ name, version }) => {
+        const manifest = await fetchManifest(name);
+        return getPkgDetails(manifest, name, version, force, tmpDir);
+    });
     const results = await Promise.all(promises);
 
     return { results };

--- a/src/page-props/results.ts
+++ b/src/page-props/results.ts
@@ -3,13 +3,18 @@ import { findAll } from '../util/backend/db';
 import { getVersionsForChart, getPublishDate } from '../util/npm-api';
 import { getPkgDetails } from './common';
 
-export async function getResultProps(query: ParsedUrlQuery, tmpDir: string): Promise<ResultProps> {
+export async function getResultProps(
+    query: ParsedUrlQuery,
+    manifest: NpmManifest | null,
+    tmpDir: string,
+): Promise<ResultProps> {
     if (!query || typeof query.p !== 'string') {
         throw new Error(`Unknown query string ${query}`);
     }
     const parsed = parsePackageString(query.p);
     const force = query.force === '1';
-    const { pkgSize, allVersions, cacheResult, isLatest, manifest } = await getPkgDetails(
+    const { pkgSize, allVersions, cacheResult, isLatest } = await getPkgDetails(
+        manifest,
         parsed.name,
         parsed.version,
         force,

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -105,7 +105,7 @@ export async function renderPage(
     let title = 'Package Phobia';
     let description =
         'Find the cost of adding a npm dependency to your Node.js project. Compare package install size and publish size over time.';
-    if (pages.result && typeof query.p === 'string') {
+    if (pathname === pages.result && typeof query.p === 'string') {
         try {
             const parsed = parsePackageString(query.p);
             manifest = await fetchManifest(parsed.name);

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -15,12 +15,11 @@ import { getCompareProps } from '../page-props/compare';
 import { containerId, pages, productionHostname } from '../util/constants';
 import OctocatCorner from '../components/OctocatCorner';
 import Logo from '../components/Logo';
+import { fetchManifest } from '../util/npm-api';
+import { parsePackageString } from '../util/npm-parser';
 
 const existingPaths = new Set(Object.values(pages));
 const logoSize = 108;
-const title = 'Package Phobia';
-const description =
-    'Find the cost of adding a npm dependency to your Node.js project. Compare package install size and publish size over time.';
 const css = `
 body {
     margin: 0;
@@ -102,6 +101,20 @@ export async function renderPage(
     gaId = '',
 ) {
     res.statusCode = getStatusCode(pathname);
+    let manifest: NpmManifest | null = null;
+    let title = 'Package Phobia';
+    let description =
+        'Find the cost of adding a npm dependency to your Node.js project. Compare package install size and publish size over time.';
+    if (pages.result && typeof query.p === 'string') {
+        try {
+            const parsed = parsePackageString(query.p);
+            manifest = await fetchManifest(parsed.name);
+            title = `${manifest.name} - Package Phobia`;
+            description = `Find the size of ${manifest.name}: ${manifest.description} - Package Phobia`;
+        } catch (err) {
+            console.error(err);
+        }
+    }
     res.write(`<!DOCTYPE html>
             <html lang="en">
             <head>
@@ -129,7 +142,7 @@ export async function renderPage(
             </script>
             ${OctocatCorner()}
             <div id="${containerId}">`);
-    const factory = await routePage(pathname, query, tmpDir);
+    const factory = await routePage(pathname, query, manifest, tmpDir);
     const stream = renderToNodeStream(factory);
     stream.pipe(res, { end: false });
     stream.on('end', () => {
@@ -160,7 +173,12 @@ export async function renderPage(
     });
 }
 
-async function routePage(pathname: string, query: ParsedUrlQuery, tmpDir: string) {
+async function routePage(
+    pathname: string,
+    query: ParsedUrlQuery,
+    manifest: NpmManifest | null,
+    tmpDir: string,
+) {
     try {
         switch (pathname) {
             case pages.index:
@@ -171,7 +189,7 @@ async function routePage(pathname: string, query: ParsedUrlQuery, tmpDir: string
                 return (query.p || '').includes(',') ? (
                     <Compare {...await getCompareProps(query, tmpDir)} />
                 ) : (
-                    <Result {...await getResultProps(query, tmpDir)} />
+                    <Result {...await getResultProps(query, manifest, tmpDir)} />
                 );
             default:
                 return <NotFound />;

--- a/src/util/npm-api.ts
+++ b/src/util/npm-api.ts
@@ -12,10 +12,10 @@ export async function fetchManifest(name: string) {
     const response = await fetch(`${NPM_REGISTRY_URL}/${encodedPackage}`);
     const manifest: NpmManifest = await response.json();
     if (response.status === 404 || !manifest || Object.keys(manifest).length === 0) {
-        throw new Error('Package not found');
+        throw new Error(`Package "${name}" not found`);
     }
     if (manifest.time.unpublished) {
-        throw new Error('Package was unpublished');
+        throw new Error(`Package "${name}" was unpublished`);
     }
     return manifest;
 }

--- a/test/npm-api-test.ts
+++ b/test/npm-api-test.ts
@@ -2,6 +2,8 @@ import * as npmapi from '../src/util/npm-api';
 import test from 'tape';
 
 const manifest = {
+    name: 'manifest example',
+    description: 'manifest example description',
     versions: {
         '1.0.0': '',
         '1.0.1': '',
@@ -45,6 +47,8 @@ const allVersions = [
 ];
 
 const manifestUnordered = {
+    name: 'manifest unordered example',
+    description: 'manifest unordered example description',
     versions: {
         '1.3.0-alpha': '',
         '1.3.0-beta': '',


### PR DESCRIPTION
This PR add a dynamic `title` and `description` meta tag based on the npm manifest.

This was tricky because we used to do routing after emitting meta tags.

This PR attempts to fetch the npm manifest before any routing and then passes it to both meta tags and routing below.

Fixes #449 