### PR TITLE
Add filtered chart feature

### DIFF
--- a/src/interfaces/types.d.ts
+++ b/src/interfaces/types.d.ts
@@ -45,6 +45,7 @@ interface ResultProps {
     readings: PkgSize[];
     cacheResult: boolean;
     isLatest: boolean;
+    inputStr: string;
 }
 
 interface ComparePackage {
@@ -54,6 +55,7 @@ interface ComparePackage {
 }
 
 interface CompareProps {
+    inputStr: string;
     results: ComparePackage[];
 }
 

--- a/src/page-props/compare.ts
+++ b/src/page-props/compare.ts
@@ -1,19 +1,17 @@
 import { fetchManifest } from '../util/npm-api';
-import { parsePackageString } from '../util/npm-parser';
 import { getPkgDetails } from './common';
 
-export async function getCompareProps(query: ParsedUrlQuery, tmpDir: string) {
-    if (!query || typeof query.p !== 'string') {
-        throw new Error(`Unknown query string ${query}`);
-    }
-    const packages = query.p.split(',').map(parsePackageString);
-    const force = query.force === '1';
-
-    const promises = packages.map(async ({ name, version }) => {
+export async function getCompareProps(
+    inputStr: string,
+    pkgVersions: PackageVersion[],
+    force: boolean,
+    tmpDir: string,
+): Promise<CompareProps> {
+    const promises = pkgVersions.map(async ({ name, version }) => {
         const manifest = await fetchManifest(name);
         return getPkgDetails(manifest, name, version, force, tmpDir);
     });
     const results = await Promise.all(promises);
 
-    return { results };
+    return { inputStr, results };
 }

--- a/src/pages/compare.tsx
+++ b/src/pages/compare.tsx
@@ -8,91 +8,77 @@ import { Stat } from '../components/Stats';
 import SearchBar from '../components/SearchBar';
 import EthicalAd from '../components/EthicalAd';
 
-export default class ComparePage extends React.Component<CompareProps, {}> {
-    render() {
-        const { results } = this.props;
+export default ({ inputStr, results }: CompareProps) => {
+    const resultsToPrint = results.map(({ pkgSize, isLatest }) => {
+        const { name, version, installSize, publishSize } = pkgSize;
+        const install = getReadableFileSize(installSize);
+        const publish = getReadableFileSize(publishSize);
+        const pkgNameAndVersion = isLatest ? name : `${name}@${version}`;
+        const badgeUrl = getBadgeUrl(pkgSize, isLatest);
+        return {
+            name,
+            version,
+            install,
+            publish,
+            installSize,
+            pkgNameAndVersion,
+            badgeUrl,
+        };
+    });
 
-        const resultsToPrint = results.map(({ pkgSize, isLatest }) => {
-            const { name, version, installSize, publishSize } = pkgSize;
-            const install = getReadableFileSize(installSize);
-            const publish = getReadableFileSize(publishSize);
-            const pkgNameAndVersion = isLatest ? name : `${name}@${version}`;
-            const badgeUrl = getBadgeUrl(pkgSize, isLatest);
-            return {
-                name,
-                version,
-                install,
-                publish,
-                installSize,
-                pkgNameAndVersion,
-                badgeUrl,
-            };
-        });
-
-        return (
-            <>
-                <PageContainer>
-                    <SearchBar
-                        autoFocus={false}
-                        defaultValue={resultsToPrint
-                            .map(result => result.pkgNameAndVersion)
-                            .join(',')}
-                    />
-                    <div style={{ maxWidth: '100%', overflow: 'auto' }}>
-                        <table style={{ marginTop: '30px' }}>
-                            <tbody>
-                                {resultsToPrint
-                                    .filter(
-                                        result =>
-                                            result.version && result.version !== versionUnknown,
-                                    )
-                                    .sort((a, b) => b.installSize - a.installSize)
-                                    .map(result => (
-                                        <tr key={result.pkgNameAndVersion}>
-                                            <td
-                                                style={{ fontSize: '1.5rem', paddingRight: '2rem' }}
+    return (
+        <>
+            <PageContainer>
+                <SearchBar autoFocus={false} defaultValue={inputStr} />
+                <div style={{ maxWidth: '100%', overflow: 'auto' }}>
+                    <table style={{ marginTop: '30px' }}>
+                        <tbody>
+                            {resultsToPrint
+                                .filter(
+                                    result => result.version && result.version !== versionUnknown,
+                                )
+                                .sort((a, b) => b.installSize - a.installSize)
+                                .map(result => (
+                                    <tr key={result.pkgNameAndVersion}>
+                                        <td style={{ fontSize: '1.5rem', paddingRight: '2rem' }}>
+                                            <a
+                                                style={{ textDecoration: 'none' }}
+                                                href={
+                                                    pages.result + '?p=' + result.pkgNameAndVersion
+                                                }
                                             >
-                                                <a
-                                                    style={{ textDecoration: 'none' }}
-                                                    href={
-                                                        pages.result +
-                                                        '?p=' +
-                                                        result.pkgNameAndVersion
-                                                    }
-                                                >
-                                                    <Stat
-                                                        size={result.name}
-                                                        unit=""
-                                                        label={result.version}
-                                                        scale={0.75}
-                                                        color="#16864d"
-                                                        textAlign="right"
-                                                    />
-                                                </a>
-                                            </td>
-                                            <td style={{ padding: '0 2rem', textAlign: 'center' }}>
                                                 <Stat
-                                                    {...result.install}
-                                                    label="Install"
+                                                    size={result.name}
+                                                    unit=""
+                                                    label={result.version}
                                                     scale={0.75}
+                                                    color="#16864d"
+                                                    textAlign="right"
                                                 />
-                                            </td>
-                                            <td style={{ padding: '0 2rem', textAlign: 'center' }}>
-                                                <Stat
-                                                    {...result.publish}
-                                                    label="Publish"
-                                                    scale={0.75}
-                                                />
-                                            </td>
-                                        </tr>
-                                    ))}
-                            </tbody>
-                        </table>
-                    </div>
-                    <EthicalAd />
-                </PageContainer>
-                <Footer />
-            </>
-        );
-    }
-}
+                                            </a>
+                                        </td>
+                                        <td style={{ padding: '0 2rem', textAlign: 'center' }}>
+                                            <Stat
+                                                {...result.install}
+                                                label="Install"
+                                                scale={0.75}
+                                            />
+                                        </td>
+                                        <td style={{ padding: '0 2rem', textAlign: 'center' }}>
+                                            <Stat
+                                                {...result.publish}
+                                                label="Publish"
+                                                scale={0.75}
+                                            />
+                                        </td>
+                                    </tr>
+                                ))}
+                        </tbody>
+                    </table>
+                </div>
+                <EthicalAd />
+            </PageContainer>
+            <Footer />
+        </>
+    );
+};

--- a/src/pages/result.tsx
+++ b/src/pages/result.tsx
@@ -19,7 +19,7 @@ const error: React.CSSProperties = {
     textAlign: 'center',
 };
 
-export default ({ pkgSize, readings, isLatest }: ResultProps) => {
+export default ({ pkgSize, readings, isLatest, inputStr }: ResultProps) => {
     const exists = pkgSize.version !== versionUnknown;
     const install = getReadableFileSize(pkgSize.installSize);
     const publish = getReadableFileSize(pkgSize.publishSize);
@@ -29,7 +29,7 @@ export default ({ pkgSize, readings, isLatest }: ResultProps) => {
     return (
         <>
             <PageContainer>
-                <SearchBar autoFocus={false} defaultValue={pkgNameAndVersion} />
+                <SearchBar autoFocus={false} defaultValue={inputStr} />
 
                 {exists ? (
                     <div style={{ display: 'flex', padding: '10px 0' }}>

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,7 +3,7 @@ import { parse } from 'url';
 import { mimeType, cacheControl } from './util/backend/lookup';
 import { renderPage } from './pages/_document';
 import { pages, versionUnknown } from './util/constants';
-import { getResultProps } from './page-props/results';
+import { getPkgDetails } from './page-props/common';
 import { getApiResponseSize, getBadgeSvg } from './util/badge';
 import { parsePackageString } from './util/npm-parser';
 import semver from 'semver';
@@ -24,18 +24,31 @@ export async function handler(req: IncomingMessage, res: ServerResponse) {
     if (!pathname || pathname === '/') {
         pathname = pages.index;
     }
+    const force = query.force === '1';
     try {
         if (pathname === pages.badge) {
             const parsed = parsePackageString(query.p as string);
             const manifest = await fetchManifest(parsed.name);
-            const { pkgSize, cacheResult } = await getResultProps(query, manifest, TMPDIR);
+            const { pkgSize, cacheResult } = await getPkgDetails(
+                manifest,
+                parsed.name,
+                parsed.version,
+                force,
+                TMPDIR,
+            );
             res.setHeader('Content-Type', mimeType('*.svg'));
             res.setHeader('Cache-Control', cacheControl(isProd, cacheResult ? 7 : 0));
             res.end(getBadgeSvg(pkgSize));
         } else if (pathname === pages.apiv1 || pathname === pages.apiv2) {
             const parsed = parsePackageString(query.p as string);
             const manifest = await fetchManifest(parsed.name);
-            const { pkgSize, cacheResult } = await getResultProps(query, manifest, TMPDIR);
+            const { pkgSize, cacheResult } = await getPkgDetails(
+                manifest,
+                parsed.name,
+                parsed.version,
+                force,
+                TMPDIR,
+            );
             const { publishSize, installSize, name, version, publishFiles, installFiles } = pkgSize;
             let result: ApiResponseV1 | ApiResponseV2;
             if (pathname === pages.apiv1) {


### PR DESCRIPTION
This new feature allows you to filter specific versions in the chart in order to compare versions that are not chronologically adjacent.

For example, comparing each major version of TypeScript where there might be years in between.

https://packagephobia.com/result?p=typescript%400.8.1%2Ctypescript%401.0.0%2Ctypescript%402.0.2%2Ctypescript%403.0.1%2Ctypescript%404.0.2


## Before

<img src="https://user-images.githubusercontent.com/229881/109435769-1d8cb180-79ea-11eb-997e-94b4fc926e38.png" width="400" />


## After

<img src="https://user-images.githubusercontent.com/229881/109435795-3ac18000-79ea-11eb-8c1a-de3182041dc5.png" width="400" />


# One more thing

This also fixes #684 😉 
