### PR TITLE
Update readme with mention of AWS Blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 - 🛡️ Get a badge/shield for your README
 - 📡 Fetch size from json API to integrate into any tool
 
-*...as seen on [npm weekly](https://medium.com/npm-inc/87f3bd77529#1883) and [ponyfoo weekly](https://ponyfoo.com/weekly/111/how-css-works-integration-testing-angular-6-optimizing-react-and-the-future-of-javascript) and [habr](https://habr.com/company/zfort/blog/354060/) and [rwpod](https://www.rwpod.com/posts/2018/04/23/podcast-06-16.html) and [wolf report](https://michael-wolfenden.github.io/2018/04/20/april-20th-2018/) and [the changelog](https://changelog.com/news/find-the-cost-of-adding-a-new-dependency-to-your-project-gbj6) and all over twitter*
+*...as seen on [AWS Developer Tools Blog](https://aws.amazon.com/blogs/developer/how-we-halved-the-publish-size-of-modular-aws-sdk-for-javascript-clients/) and [npm weekly](https://medium.com/npm-inc/87f3bd77529#1883) and [ponyfoo weekly](https://ponyfoo.com/weekly/111/how-css-works-integration-testing-angular-6-optimizing-react-and-the-future-of-javascript) and [habr](https://habr.com/company/zfort/blog/354060/) and [rwpod](https://www.rwpod.com/posts/2018/04/23/podcast-06-16.html) and [wolf report](https://michael-wolfenden.github.io/2018/04/20/april-20th-2018/) and [the changelog](https://changelog.com/news/find-the-cost-of-adding-a-new-dependency-to-your-project-gbj6) and all over twitter*
 
 ## What is the purpose?
 


### PR DESCRIPTION
https://aws.amazon.com/blogs/developer/how-we-halved-the-publish-size-of-modular-aws-sdk-for-javascript-clients/