### PR TITLE
Fixed issue with label for longer package versions

### DIFF
--- a/src/components/BarGraph.tsx
+++ b/src/components/BarGraph.tsx
@@ -9,7 +9,7 @@ const stylesheet = `
     margin:0;
     justify-content:center;
     max-width: 80vw;
-    overflow-x: hidden;
+    overflow-x: auto;
 }
 .bar-graph__bar-group{
     height:100%;
@@ -47,15 +47,19 @@ const stylesheet = `
 .bar-graph__bar-version{
     font-size:0.8rem;
     position:absolute;
-    bottom:-50px;
+    bottom:-80px;
+    padding-top:0.4vw;
     font-weight:400;
     display:block;
+    width:45px;
+    height:1.6vw;
+    min-height:15px;
     transform:rotate(-90deg);
-    transform-origin:50% 50%;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    width:150%;
+    transform-origin:0% 0%;
+    text-overflow:ellipsis;
+    overflow:hidden;
+	white-space: nowrap;
+    text-align:left;
     padding-bottom:50%;
     text-align: left;
     font-variant-numeric:tabular-nums;

--- a/src/components/BarGraph.tsx
+++ b/src/components/BarGraph.tsx
@@ -52,7 +52,11 @@ const stylesheet = `
     display:block;
     transform:rotate(-90deg);
     transform-origin:50% 50%;
-    width:100%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    width:150%;
+    padding-bottom:50%;
     text-align:right;
     font-variant-numeric:tabular-nums;
     color:#666E78;

--- a/src/components/BarGraph.tsx
+++ b/src/components/BarGraph.tsx
@@ -9,7 +9,7 @@ const stylesheet = `
     margin:0;
     justify-content:center;
     max-width: 80vw;
-    overflow-x: auto;
+    overflow-x: hidden;
 }
 .bar-graph__bar-group{
     height:100%;
@@ -57,7 +57,7 @@ const stylesheet = `
     text-overflow: ellipsis;
     width:150%;
     padding-bottom:50%;
-    text-align:right;
+    text-align: left;
     font-variant-numeric:tabular-nums;
     color:#666E78;
     transition:opacity 0.2s,color 0.2s;

--- a/src/components/BarGraph.tsx
+++ b/src/components/BarGraph.tsx
@@ -58,10 +58,10 @@ const stylesheet = `
     transform-origin:0% 0%;
     text-overflow:ellipsis;
     overflow:hidden;
-	white-space: nowrap;
+    white-space:nowrap;
     text-align:left;
     padding-bottom:50%;
-    text-align: left;
+    text-align:left;
     font-variant-numeric:tabular-nums;
     color:#666E78;
     transition:opacity 0.2s,color 0.2s;


### PR DESCRIPTION
Labels for longer package versions were overlapping the bars in the chart. Fixed with `text-overflow`


- Before
![image](https://user-images.githubusercontent.com/59320016/138613473-ca73f06f-6b48-41ca-ac3d-9f5f3563f528.png)
- After
![image](https://user-images.githubusercontent.com/59320016/138613493-9451de5a-f3ec-4232-80da-51eec32366e4.png)

Closes #451 