### PR TITLE
Switch to `ioredis` client

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,9 +29,7 @@ Create a `.env` file in the root directory.
 
 ```
 # required settings
-REDIS_HOST="127.0.0.1"
-REDIS_PORT="6379"
-REDIS_PASS=""
+REDIS_URL="redis://127.0.0.1:6379"
 GA_ID=""
 
 # optional settings

--- a/package-lock.json
+++ b/package-lock.json
@@ -3,6 +3,15 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
+    "@types/ioredis": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.28.1.tgz",
+      "integrity": "sha512-raYHPqRWrfnEoym94BY28mG1+tcZqh3dsp2q7x5IyMAAEvIdu+H0X8diASMpncIm+oHyH9dalOeOnGOL/YnuOA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/node": {
       "version": "16.11.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.10.tgz",
@@ -43,15 +52,6 @@
       "dev": true,
       "requires": {
         "@types/react": "*"
-      }
-    },
-    "@types/redis": {
-      "version": "2.8.32",
-      "resolved": "https://registry.npmjs.org/@types/redis/-/redis-2.8.32.tgz",
-      "integrity": "sha512-7jkMKxcGq9p242exlbsVzuJb57KqHRhNl4dHoQu2Y5v9bCAbtIXXH0R3HleSQW4CTOqpHIYUW3t6tpUj4BVQ+w==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
       }
     },
     "@types/scheduler": {
@@ -124,6 +124,11 @@
         "get-intrinsic": "^1.0.2"
       }
     },
+    "cluster-key-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz",
+      "integrity": "sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw=="
+    },
     "combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -144,6 +149,14 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
       "integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA==",
       "dev": true
+    },
+    "debug": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "requires": {
+        "ms": "2.1.2"
+      }
     },
     "deep-equal": {
       "version": "2.0.5",
@@ -190,9 +203,9 @@
       "dev": true
     },
     "denque": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.0.tgz",
-      "integrity": "sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
+      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw=="
     },
     "dotignore": {
       "version": "0.1.2",
@@ -403,6 +416,24 @@
         "side-channel": "^1.0.4"
       }
     },
+    "ioredis": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.28.2.tgz",
+      "integrity": "sha512-kQ+Iv7+c6HsDdPP2XUHaMv8DhnSeAeKEwMbaoqsXYbO+03dItXt7+5jGQDRyjdRUV2rFJbzg7P4Qt1iX2tqkOg==",
+      "requires": {
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.1",
+        "denque": "^1.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isarguments": "^3.1.0",
+        "p-map": "^2.1.0",
+        "redis-commands": "1.7.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      }
+    },
     "is-arguments": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
@@ -562,6 +593,21 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -607,6 +653,11 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node-fetch": {
       "version": "2.6.1",
@@ -3755,6 +3806,11 @@
         "wrappy": "1"
       }
     },
+    "p-map": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -3790,17 +3846,6 @@
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "scheduler": "^0.20.2"
-      }
-    },
-    "redis": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-3.1.2.tgz",
-      "integrity": "sha512-grn5KoZLr/qrRQVwoSkmzdbw6pwF+/rwODtrOr6vuBRiR/f3rjSTGupbF90Zpqm2oenix8Do6RV7pYEkGwlKkw==",
-      "requires": {
-        "denque": "^1.5.0",
-        "redis-commands": "^1.7.0",
-        "redis-errors": "^1.2.0",
-        "redis-parser": "^3.0.0"
       }
     },
     "redis-commands": {
@@ -3877,6 +3922,11 @@
         "get-intrinsic": "^1.0.2",
         "object-inspect": "^1.9.0"
       }
+    },
+    "standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
     },
     "string.prototype.trim": {
       "version": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -15,19 +15,19 @@
   "license": "MIT",
   "dependencies": {
     "badgen": "^3.2.2",
+    "ioredis": "^4.28.2",
     "node-fetch": "^2.6.1",
     "npm": "^6.14.11",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "redis": "^3.1.2",
     "semver": "^7.3.5"
   },
   "devDependencies": {
+    "@types/ioredis": "^4.28.1",
     "@types/node": "^16.11.10",
     "@types/node-fetch": "^2.5.12",
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",
-    "@types/redis": "^2.8.32",
     "@types/semver": "^7.3.9",
     "@types/tape": "^4.13.2",
     "@vercel/git-hooks": "^1.0.0",

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -215,12 +215,8 @@ async function routePage(
             default:
                 return <NotFound />;
         }
-    } catch (e) {
-        if (e instanceof Error) {
-            console.error(`ERROR: ${e.message}`);
-        } else {
-            console.error(`ERROR: ${e}`);
-        }
+    } catch (err) {
+        console.error('Unexpected Error Occurred...', err);
         return <ServerError />;
     }
 }

--- a/src/util/backend/db.ts
+++ b/src/util/backend/db.ts
@@ -1,17 +1,19 @@
-import { createClient } from 'redis';
+import Redis from 'ioredis';
 
-const { REDIS_HOST = '127.0.0.1', REDIS_PORT = '14555', REDIS_PASS } = process.env;
+const { REDIS_URL = '' } = process.env;
+delete process.env.REDIS_URL;
 
-delete process.env.REDIS_HOST;
-delete process.env.REDIS_PORT;
-delete process.env.REDIS_PASS;
+if (!REDIS_URL) {
+    throw new Error('Missing REDIS_URL environment variable');
+}
 
-const client = createClient({
-    host: REDIS_HOST,
-    port: parseInt(REDIS_PORT),
-    password: REDIS_PASS || undefined,
-    tls: REDIS_HOST !== '127.0.0.1',
-});
+try {
+    new URL(REDIS_URL);
+} catch (err) {
+    throw new Error('Invalid REDIS_URL environment variable');
+}
+
+const client = new Redis(REDIS_URL);
 
 client.on('error', err => {
     console.error('Redis error: ', err);


### PR DESCRIPTION
There are too many breaking changes in `redis` so we can switch to `ioredis` and get the same API.

Also switch to a single env var for the REDIS_URL so its easier to swap.

Closes #863 