### PR TITLE
Update dependencies and regenerate package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,21 @@
 {
   "name": "packagephobia",
-  "requires": true,
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "@types/ioredis": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.28.1.tgz",
-      "integrity": "sha512-raYHPqRWrfnEoym94BY28mG1+tcZqh3dsp2q7x5IyMAAEvIdu+H0X8diASMpncIm+oHyH9dalOeOnGOL/YnuOA==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.28.2.tgz",
+      "integrity": "sha512-kOCG4ExodOAoslFjsUzwAK1fxqVRx3JX5m7lm3MkWf5WkDwNTtXBtlBig6cQyFwS7P7TPaTWRreQaMwl7e1FFA==",
       "dev": true,
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/node": {
-      "version": "16.11.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.10.tgz",
-      "integrity": "sha512-3aRnHa1KlOEEhJ6+CvyHKK5vE9BcLGjtUpwvqYLRvYNQKMfabu3BwfJaA/SLW8dxe28LsNDjtHwePTuzn3gmOA==",
+      "version": "16.11.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.11.tgz",
+      "integrity": "sha512-KB0sixD67CeecHC33MYn+eYARkqTheIRNuu97y2XMjR7Wu3XibO1vaY6VBV6O/a89SPI81cEUIYT87UqUWlZNw==",
       "dev": true
     },
     "@types/prop-types": {
@@ -85,14 +85,12 @@
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -116,8 +114,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "csstype": {
       "version": "3.0.10",
@@ -258,8 +255,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "function-bind": {
       "version": "1.1.1",
@@ -298,7 +294,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
       "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -351,7 +346,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -360,8 +354,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "internal-slot": {
       "version": "1.0.3",
@@ -586,7 +579,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -603,11 +595,10 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "npm": {
-      "version": "6.14.11",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-6.14.11.tgz",
-      "integrity": "sha512-1Zh7LjuIoEhIyjkBflSSGzfjuPQwDlghNloppjruOH5bmj9midT9qcNT0tRUZRR04shU9ekrxNy9+UTBrqeBpQ==",
+      "version": "6.14.15",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-6.14.15.tgz",
+      "integrity": "sha512-dkcQc4n+DiJAMYG2haNAMyJbmuvevjXz+WC9dCUzodw8EovwTIc6CATSsTEplCY6c0jG4OshxFGFJsrnKJguWA==",
       "requires": {
-        "JSONStream": "^1.3.5",
         "abbrev": "~1.1.1",
         "ansicolors": "~0.3.2",
         "ansistyles": "~0.1.3",
@@ -638,7 +629,7 @@
         "glob": "^7.1.6",
         "graceful-fs": "^4.2.4",
         "has-unicode": "~2.0.1",
-        "hosted-git-info": "^2.8.8",
+        "hosted-git-info": "^2.8.9",
         "iferr": "^1.0.2",
         "imurmurhash": "*",
         "infer-owner": "^1.0.4",
@@ -648,6 +639,7 @@
         "init-package-json": "^1.10.3",
         "is-cidr": "^3.0.0",
         "json-parse-better-errors": "^1.0.2",
+        "JSONStream": "^1.3.5",
         "lazy-property": "~1.0.0",
         "libcipm": "^4.0.8",
         "libnpm": "^3.0.1",
@@ -714,9 +706,9 @@
         "slide": "~1.1.6",
         "sorted-object": "~2.0.1",
         "sorted-union-stream": "~2.1.3",
-        "ssri": "^6.0.1",
+        "ssri": "^6.0.2",
         "stringify-package": "^1.0.1",
-        "tar": "^4.4.13",
+        "tar": "^4.4.19",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^1.3.0",
         "uid-number": "0.0.6",
@@ -732,14 +724,6 @@
         "write-file-atomic": "^2.4.3"
       },
       "dependencies": {
-        "JSONStream": {
-          "version": "1.3.5",
-          "bundled": true,
-          "requires": {
-            "jsonparse": "^1.2.0",
-            "through": ">=2.2.7 <3"
-          }
-        },
         "abbrev": {
           "version": "1.1.1",
           "bundled": true
@@ -1762,7 +1746,7 @@
           "bundled": true
         },
         "hosted-git-info": {
-          "version": "2.8.8",
+          "version": "2.8.9",
           "bundled": true
         },
         "http-cache-semantics": {
@@ -1989,6 +1973,14 @@
         "jsonparse": {
           "version": "1.3.1",
           "bundled": true
+        },
+        "JSONStream": {
+          "version": "1.3.5",
+          "bundled": true,
+          "requires": {
+            "jsonparse": "^1.2.0",
+            "through": ">=2.2.7 <3"
+          }
         },
         "jsprim": {
           "version": "1.4.1",
@@ -2529,9 +2521,9 @@
           "version": "4.0.7",
           "bundled": true,
           "requires": {
-            "JSONStream": "^1.3.4",
             "bluebird": "^3.5.1",
             "figgy-pudding": "^3.4.1",
+            "JSONStream": "^1.3.4",
             "lru-cache": "^5.1.1",
             "make-fetch-happen": "^5.0.0",
             "npm-package-arg": "^6.1.0",
@@ -2724,7 +2716,7 @@
           "bundled": true
         },
         "path-parse": {
-          "version": "1.0.6",
+          "version": "1.0.7",
           "bundled": true
         },
         "performance-now": {
@@ -3158,7 +3150,7 @@
           }
         },
         "ssri": {
-          "version": "6.0.1",
+          "version": "6.0.2",
           "bundled": true,
           "requires": {
             "figgy-pudding": "^3.5.1"
@@ -3210,6 +3202,19 @@
           "version": "2.0.0",
           "bundled": true
         },
+        "string_decoder": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.2.0",
+              "bundled": true
+            }
+          }
+        },
         "string-width": {
           "version": "2.1.1",
           "bundled": true,
@@ -3232,19 +3237,6 @@
               "requires": {
                 "ansi-regex": "^3.0.0"
               }
-            }
-          }
-        },
-        "string_decoder": {
-          "version": "1.3.0",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "~5.2.0"
-          },
-          "dependencies": {
-            "safe-buffer": {
-              "version": "5.2.0",
-              "bundled": true
             }
           }
         },
@@ -3275,16 +3267,16 @@
           }
         },
         "tar": {
-          "version": "4.4.13",
+          "version": "4.4.19",
           "bundled": true,
           "requires": {
-            "chownr": "^1.1.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.8.6",
-            "minizlib": "^1.2.1",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.3"
+            "chownr": "^1.1.4",
+            "fs-minipass": "^1.2.7",
+            "minipass": "^2.9.0",
+            "minizlib": "^1.3.3",
+            "mkdirp": "^0.5.5",
+            "safe-buffer": "^5.2.1",
+            "yallist": "^3.1.1"
           },
           "dependencies": {
             "minipass": {
@@ -3294,6 +3286,14 @@
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
               }
+            },
+            "safe-buffer": {
+              "version": "5.2.1",
+              "bundled": true
+            },
+            "yallist": {
+              "version": "3.1.1",
+              "bundled": true
             }
           }
         },
@@ -3597,7 +3597,7 @@
           "bundled": true
         },
         "y18n": {
-          "version": "4.0.0",
+          "version": "4.0.1",
           "bundled": true
         },
         "yallist": {
@@ -3739,7 +3739,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -3752,8 +3751,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-parse": {
       "version": "1.0.7",
@@ -3990,8 +3988,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "yallist": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -16,14 +16,14 @@
   "dependencies": {
     "badgen": "^3.2.2",
     "ioredis": "^4.28.2",
-    "npm": "^6.14.11",
+    "npm": "^6.14.15",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "semver": "^7.3.5"
   },
   "devDependencies": {
-    "@types/ioredis": "^4.28.1",
-    "@types/node": "^16.11.10",
+    "@types/ioredis": "^4.28.2",
+    "@types/node": "^16.11.11",
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",
     "@types/semver": "^7.3.9",


### PR DESCRIPTION
@styfle this is the best I could do on WSL. Let me know if it works for you.

I used npm 8.1.2, which ships with Node.js 16, with the `--lockfile-version=1` flag.

To verify everything is good, I'd do:

```
rm -rf ./node_modules
rm ./package-lock.json
npm i
```

and see if there are any differences (not in the package versions since those might have changed in the meantime).
