### PR TITLE
add package not found error

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -6,7 +6,7 @@ import Index from './index';
 import Result from './result';
 import Compare from './compare';
 import NotFound from './404';
-import ServerError from './500';
+import PackageNotFound from './packageNotFound';
 import ParseFailure from './parse-failure';
 
 import { getResultProps } from '../page-props/results';
@@ -17,7 +17,6 @@ import OctocatCorner from '../components/OctocatCorner';
 import Logo from '../components/Logo';
 import { fetchManifest } from '../util/npm-api';
 import { parsePackageString } from '../util/npm-parser';
-
 const existingPaths = new Set(Object.values(pages));
 const logoSize = 108;
 const css = `
@@ -216,8 +215,8 @@ async function routePage(
                 return <NotFound />;
         }
     } catch (err) {
-        console.error('Unexpected Error Occurred...', err);
-        return <ServerError />;
+        console.log('Unexpected Error Occurred...', err);
+        return <PackageNotFound />;
     }
 }
 

--- a/src/pages/packageNotFound.tsx
+++ b/src/pages/packageNotFound.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import Footer from '../components/Footer';
+import PageContainer from '../components/PageContainer';
+
+import { pages } from '../util/constants';
+
+export default () => (
+    <>
+        <PageContainer>
+            <div style={{ textAlign: 'center', marginBottom: '2rem' }}>
+                <h1>Package Not Found</h1>
+
+                <p>The package doesn't exist</p>
+                <p>
+                    <a href={pages.index}>Go Home You</a>
+                </p>
+            </div>
+        </PageContainer>
+
+        <Footer />
+    </>
+);


### PR DESCRIPTION
A few days ago, I created issue here regarding package not found error. After reading the code I was able to figure our we have 404 page which occurs when there is misspelled/intentional URL.  occurs at src/pages/_document.tsx line: 198-220)
However, when server can not find it we were returning ServerError which seems invalid and confusing. Rather we should return packageNotFound error and link the to the main page. I hope it will solve the issue temporarily and we can return ServerError in specific cases later on development stages. 