### PR TITLE
feat: return a badge when package not found

### DIFF
--- a/src/util/badge.ts
+++ b/src/util/badge.ts
@@ -1,5 +1,5 @@
 import { badgen } from 'badgen';
-import { getReadableFileSize, getHexColor } from './npm-parser';
+import { getReadableFileSize, getHexColor, color } from './npm-parser';
 import { pages, productionHostname } from '../util/constants';
 
 export function getBadgeSvg(pkgSize: PkgSize) {
@@ -7,8 +7,8 @@ export function getBadgeSvg(pkgSize: PkgSize) {
     const { pretty } = getReadableFileSize(installSize);
     return badgen({
         label: 'install size',
-        status: pretty,
-        color: getHexColor(installSize),
+        status: installSize ? pretty : 'package not found',
+        color: installSize ? getHexColor(installSize) : color.red,
     });
 }
 


### PR DESCRIPTION
### Description

Improvement that allows to get a red badge with the message "package not found" instead of a 500 error

Fix this:
![image](https://user-images.githubusercontent.com/8747883/228005181-4009b992-18de-4434-9dd2-7503ce2aa89b.png)
