### PR TITLE
fix: 404 not found should avoid function invocation

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -34,7 +34,7 @@ export default () => (
             <form
                 style={{ marginTop: '30px' }}
                 method="post"
-                action={pages.compare}
+                action={pages.scanResults}
                 encType="multipart/form-data"
             >
                 <label>

--- a/src/server.ts
+++ b/src/server.ts
@@ -76,7 +76,7 @@ export async function handler(req: IncomingMessage, res: ServerResponse) {
             res.setHeader('Content-Type', mimeType(pathname));
             res.setHeader('Cache-Control', cacheControl(isProd, cacheResult ? 7 : 0));
             res.end(JSON.stringify(result));
-        } else if (pathname === pages.compare) {
+        } else if (pathname === pages.scanResults) {
             let data: Buffer[] = [];
             req.on('data', chunk => data.push(chunk));
             req.on('end', () => {

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -1,7 +1,10 @@
+/**
+ * The `pages` here should match the `rewrites` in vercel.json
+ */
 export const pages = {
     index: '/index',
     result: '/result',
-    compare: '/scan-results',
+    scanResults: '/scan-results',
     parseFailure: '/parse-failure',
     badge: '/badge',
     apiv1: '/api.json',

--- a/vercel.json
+++ b/vercel.json
@@ -14,6 +14,12 @@
         ]
     }],
     "rewrites": [
-        { "source": "/(.*)", "destination": "/api/index" }
+        { "source": "/", "destination": "/api/index" },
+        { "source": "/result", "destination": "/api/index" },
+        { "source": "/scan-results", "destination": "/api/index" },
+        { "source": "/parse-failure", "destination": "/api/index" },
+        { "source": "/badge", "destination": "/api/index" },
+        { "source": "/api.json", "destination": "/api/index" },
+        { "source": "/v2/api.json", "destination": "/api/index" }
     ]
 }


### PR DESCRIPTION
This will avoid serverless function invocations for 404s.

For example, the function logs show attackers looking for non-existing files such as:

<img width="1125" alt="image" src="https://github.com/styfle/packagephobia/assets/229881/66a50a3d-b351-47ff-b169-b4ec87f72afa">

Instead of rewriting all paths, we can rewrite only paths we know are handled by the function.