### PR TITLE
chore: add lru cache to improve perf

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "dependencies": {
         "badgen": "^3.2.2",
         "ioredis": "^5.1.0",
+        "lru-cache": "^10.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "semver": "^7.5.2"
@@ -171,14 +172,11 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
+      "integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
       "engines": {
-        "node": ">=10"
+        "node": "14 || >=16.14"
       }
     },
     "node_modules/ms": {
@@ -3131,6 +3129,17 @@
       },
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
       },
       "engines": {
         "node": ">=10"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "badgen": "^3.2.2",
     "ioredis": "^5.1.0",
+    "lru-cache": "^10.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "semver": "^7.5.2"

--- a/src/page-props/common.ts
+++ b/src/page-props/common.ts
@@ -1,5 +1,5 @@
 import { findOne, insert } from '../util/backend/db';
-import { getAllDistTags, getAllVersions, getPublishDate } from '../util/npm-api';
+import { getAllDistTags, getPublishDate } from '../util/npm-api';
 import { calculatePackageSize } from '../util/backend/npm-stats';
 import { versionUnknown } from '../util/constants';
 import type { NpmManifest, PkgSize } from '../types';
@@ -29,7 +29,7 @@ export async function getPkgDetails(
         cacheResult = false;
     }
 
-    const allVersions = getAllVersions(manifest);
+    const allVersions = manifest.versions;
     if (!allVersions.includes(version)) {
         console.error(`Version ${name}@${version} does not exist in npm`);
         return packageNotFound(name);

--- a/src/util/npm-api.ts
+++ b/src/util/npm-api.ts
@@ -34,7 +34,7 @@ export async function fetchManifest(name: string) {
         versions: getAllVersions(manifest),
         time: manifest.time,
         'dist-tags': manifest['dist-tags'],
-    }
+    };
     cache.set(name, cachedManifest);
     return cachedManifest;
 }

--- a/src/util/npm-api.ts
+++ b/src/util/npm-api.ts
@@ -1,6 +1,6 @@
 import https from 'https';
 import semver from 'semver';
-import { LRUCache } from 'lru-cache'
+import { LRUCache } from 'lru-cache';
 import { NotFoundError } from './not-found-error';
 import type { NpmManifest } from '../types';
 

--- a/src/util/npm-api.ts
+++ b/src/util/npm-api.ts
@@ -1,15 +1,24 @@
 import https from 'https';
 import semver from 'semver';
+import { LRUCache } from 'lru-cache'
 import { NotFoundError } from './not-found-error';
 import type { NpmManifest } from '../types';
 
 const { NPM_REGISTRY_URL = 'https://registry.npmjs.com' } = process.env;
+const cache = new LRUCache<string, NpmManifest>({ max: 5000, ttl: 1000 * 60 * 5 });
 
 /**
  * Make an API call to npm to get package manifest details
  * @param name The npm package name
  */
 export async function fetchManifest(name: string) {
+    let cachedManifest = cache.get(name);
+    if (cachedManifest) {
+        // fetch can take 2000ms or slower so we cache
+        console.log('lrucache hit');
+        return cachedManifest;
+    }
+    console.log('lrucache miss');
     const encodedPackage = escapePackageName(name);
     const manifest = await fetchJSON(`${NPM_REGISTRY_URL}/${encodedPackage}`);
     if (!isManifest(manifest)) {
@@ -18,7 +27,16 @@ export async function fetchManifest(name: string) {
     if (manifest.time.unpublished) {
         throw new NotFoundError({ resource: name });
     }
-    return manifest;
+    // only cache some properties and sort the versions by semver
+    cachedManifest = {
+        name: manifest.name,
+        description: manifest.description,
+        versions: getAllVersions(manifest),
+        time: manifest.time,
+        'dist-tags': manifest['dist-tags'],
+    }
+    cache.set(name, cachedManifest);
+    return cachedManifest;
 }
 
 function isManifest(obj: unknown): obj is NpmManifest {


### PR DESCRIPTION
The npm registry can take 2 or more seconds to fetch a package manifest, such as https://registry.npmjs.org/next

So this PR adds `lru-cache` to avoid fetching packages that we already fetched in the past 5 min.

This is particularly useful, when clicking versions in the bar chart since the manifest should be in the lru cache already.