### PR TITLE
fix: omit peer dependencies

### DIFF
--- a/src/util/backend/npm-wrapper.ts
+++ b/src/util/backend/npm-wrapper.ts
@@ -19,6 +19,8 @@ export async function npmInstall(cwd: string, cacheDir: string, name: string, ve
             npm_config_silent: 'true',
             npm_config_cache: cacheDir,
             npm_config_registry: process.env.NPM_REGISTRY_URL,
+            // Omit peerDependencies to match legacy behavior from npm@6 and `yarn@1`
+            npm_config_omit: 'peer',
         },
     });
     if (result.stderr) {


### PR DESCRIPTION
Back when Package Phobia first came out in 2018, it used `npm@5` to install dependencies and measure the size. That was later upgrade to [npm@6](https://github.com/styfle/packagephobia/pull/164) with little behavior changed.

Then upgrading node caused problems with the old version of npm so Package Phobia switched to [yarn@2](https://github.com/styfle/packagephobia/pull/959) and later [yarn@3](https://github.com/styfle/packagephobia/pull/976) which both omit peer dependencies by default.

Recently, Package Phobia switched to [npm@10](https://github.com/styfle/packagephobia/pull/1021) which will automatically install peer dependencies.

This PR will change the behavior back to omit peer dependencies.

- Fixes #1025 