### PR TITLE
fix: bump npm@10.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -860,17 +860,6 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/npm/node_modules/abort-controller": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
-    },
     "node_modules/npm/node_modules/agent-base": {
       "version": "7.1.0",
       "dev": true,
@@ -944,25 +933,6 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/base64-js": {
-      "version": "1.5.1",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/npm/node_modules/bin-links": {
       "version": "4.0.3",
       "dev": true,
@@ -994,29 +964,6 @@
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/buffer": {
-      "version": "6.0.3",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
       }
     },
     "node_modules/npm/node_modules/builtins": {
@@ -1282,11 +1229,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/npm/node_modules/delegates": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/npm/node_modules/diff": {
       "version": "5.1.0",
       "dev": true,
@@ -1332,22 +1274,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT"
-    },
-    "node_modules/npm/node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/npm/node_modules/events": {
-      "version": "3.3.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.x"
-      }
     },
     "node_modules/npm/node_modules/exponential-backoff": {
       "version": "3.1.1",
@@ -1448,17 +1374,6 @@
       "inBundle": true,
       "license": "ISC"
     },
-    "node_modules/npm/node_modules/has": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/npm/node_modules/has-unicode": {
       "version": "2.0.1",
       "dev": true,
@@ -1533,25 +1448,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/npm/node_modules/ieee754": {
-      "version": "1.2.1",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/npm/node_modules/ignore-walk": {
       "version": "6.0.4",
@@ -2438,14 +2334,6 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/npm/node_modules/process": {
-      "version": "0.11.10",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/npm/node_modules/promise-all-reject-late": {
       "version": "1.0.1",
       "dev": true,
@@ -2552,21 +2440,6 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/npm/node_modules/readable-stream": {
-      "version": "4.4.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
     "node_modules/npm/node_modules/retry": {
       "version": "0.12.0",
       "dev": true,
@@ -2575,25 +2448,6 @@
       "engines": {
         "node": ">= 4"
       }
-    },
-    "node_modules/npm/node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/npm/node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -2765,14 +2619,6 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/npm/node_modules/string-width": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@types/react": "^18.0.14",
         "@types/react-dom": "^18.0.5",
         "@types/semver": "^7.3.10",
-        "npm": "^10.2.3",
+        "npm": "^10.4.0",
         "prettier": "^3.0.0",
         "typescript": "^5.2.2"
       },
@@ -239,9 +239,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "10.2.3",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-10.2.3.tgz",
-      "integrity": "sha512-GbUui/rHTl0mW8HhJSn4A0Xg89yCR3I9otgJT1i0z1QBPOVlgbh6rlcUTpHT8Gut9O1SJjWRUU0nEcAymhG2tQ==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-10.4.0.tgz",
+      "integrity": "sha512-RS7Mx0OVfXlOcQLRePuDIYdFCVBPCNapWHplDK+mh7GDdP/Tvor4ocuybRRPSvfcRb2vjRJt1fHCqw3cr8qACQ==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -305,7 +305,6 @@
         "semver",
         "spdx-expression-parse",
         "ssri",
-        "strip-ansi",
         "supports-color",
         "tar",
         "text-table",
@@ -316,21 +315,28 @@
         "write-file-atomic"
       ],
       "dev": true,
+      "workspaces": [
+        "docs",
+        "smoke-tests",
+        "mock-globals",
+        "mock-registry",
+        "workspaces/*"
+      ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
         "@npmcli/arborist": "^7.2.1",
-        "@npmcli/config": "^8.0.1",
+        "@npmcli/config": "^8.0.2",
         "@npmcli/fs": "^3.1.0",
         "@npmcli/map-workspaces": "^3.0.4",
         "@npmcli/package-json": "^5.0.0",
-        "@npmcli/promise-spawn": "^7.0.0",
-        "@npmcli/run-script": "^7.0.2",
-        "@sigstore/tuf": "^2.1.0",
+        "@npmcli/promise-spawn": "^7.0.1",
+        "@npmcli/run-script": "^7.0.4",
+        "@sigstore/tuf": "^2.3.0",
         "abbrev": "^2.0.0",
         "archy": "~1.0.0",
-        "cacache": "^18.0.0",
+        "cacache": "^18.0.2",
         "chalk": "^5.3.0",
-        "ci-info": "^3.9.0",
+        "ci-info": "^4.0.0",
         "cli-columns": "^4.0.0",
         "cli-table3": "^0.6.3",
         "columnify": "^1.6.0",
@@ -341,16 +347,16 @@
         "hosted-git-info": "^7.0.1",
         "ini": "^4.1.1",
         "init-package-json": "^6.0.0",
-        "is-cidr": "^4.0.2",
-        "json-parse-even-better-errors": "^3.0.0",
+        "is-cidr": "^5.0.3",
+        "json-parse-even-better-errors": "^3.0.1",
         "libnpmaccess": "^8.0.1",
         "libnpmdiff": "^6.0.3",
-        "libnpmexec": "^7.0.3",
+        "libnpmexec": "^7.0.4",
         "libnpmfund": "^5.0.1",
         "libnpmhook": "^10.0.0",
         "libnpmorg": "^6.0.1",
         "libnpmpack": "^6.0.3",
-        "libnpmpublish": "^9.0.1",
+        "libnpmpublish": "^9.0.2",
         "libnpmsearch": "^7.0.0",
         "libnpmteam": "^6.0.0",
         "libnpmversion": "^5.0.1",
@@ -371,7 +377,7 @@
         "npm-user-validate": "^2.0.0",
         "npmlog": "^7.0.1",
         "p-map": "^4.0.0",
-        "pacote": "^17.0.4",
+        "pacote": "^17.0.6",
         "parse-conflict-json": "^3.0.1",
         "proc-log": "^3.0.0",
         "qrcode-terminal": "^0.12.0",
@@ -379,7 +385,6 @@
         "semver": "^7.5.4",
         "spdx-expression-parse": "^3.0.1",
         "ssri": "^10.0.5",
-        "strip-ansi": "^6.0.1",
         "supports-color": "^9.4.0",
         "tar": "^6.2.0",
         "text-table": "~0.2.0",
@@ -496,60 +501,8 @@
         "node": "^16.14.0 || >=18.0.0"
       }
     },
-    "node_modules/npm/node_modules/@npmcli/agent/node_modules/agent-base": {
-      "version": "7.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/agent/node_modules/http-proxy-agent": {
-      "version": "7.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/agent/node_modules/https-proxy-agent": {
-      "version": "7.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.0.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/agent/node_modules/socks-proxy-agent": {
-      "version": "8.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.0.2",
-        "debug": "^4.3.4",
-        "socks": "^2.7.1"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "7.2.1",
+      "version": "7.3.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -581,7 +534,7 @@
         "parse-conflict-json": "^3.0.0",
         "proc-log": "^3.0.0",
         "promise-all-reject-late": "^1.0.0",
-        "promise-call-limit": "^1.0.2",
+        "promise-call-limit": "^3.0.1",
         "read-package-json-fast": "^3.0.2",
         "semver": "^7.3.7",
         "ssri": "^10.0.5",
@@ -596,13 +549,13 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "8.0.1",
+      "version": "8.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/map-workspaces": "^3.0.2",
-        "ci-info": "^3.8.0",
+        "ci-info": "^4.0.0",
         "ini": "^4.1.0",
         "nopt": "^7.0.0",
         "proc-log": "^3.0.0",
@@ -626,6 +579,21 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/npm/node_modules/@npmcli/disparity-colors/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/npm/node_modules/@npmcli/fs": {
       "version": "3.1.0",
       "dev": true,
@@ -639,7 +607,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/git": {
-      "version": "5.0.3",
+      "version": "5.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -740,7 +708,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/promise-spawn": {
-      "version": "7.0.0",
+      "version": "7.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -764,15 +732,15 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/run-script": {
-      "version": "7.0.2",
+      "version": "7.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/node-gyp": "^3.0.0",
+        "@npmcli/package-json": "^5.0.0",
         "@npmcli/promise-spawn": "^7.0.0",
         "node-gyp": "^10.0.0",
-        "read-package-json-fast": "^3.0.0",
         "which": "^4.0.0"
       },
       "engines": {
@@ -790,13 +758,22 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/bundle": {
-      "version": "2.1.0",
+      "version": "2.1.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/protobuf-specs": "^0.2.1"
       },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/@sigstore/core": {
+      "version": "0.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
@@ -811,12 +788,13 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/sign": {
-      "version": "2.1.0",
+      "version": "2.2.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@sigstore/bundle": "^2.1.0",
+        "@sigstore/bundle": "^2.1.1",
+        "@sigstore/core": "^0.2.0",
         "@sigstore/protobuf-specs": "^0.2.1",
         "make-fetch-happen": "^13.0.0"
       },
@@ -825,13 +803,27 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/tuf": {
-      "version": "2.1.0",
+      "version": "2.3.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/protobuf-specs": "^0.2.1",
-        "tuf-js": "^2.1.0"
+        "tuf-js": "^2.2.0"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/@sigstore/verify": {
+      "version": "0.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/bundle": "^2.1.1",
+        "@sigstore/core": "^0.2.0",
+        "@sigstore/protobuf-specs": "^0.2.1"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
@@ -871,13 +863,24 @@
     "node_modules/npm/node_modules/abort-controller": {
       "version": "3.0.0",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "event-target-shim": "^5.0.0"
       },
       "engines": {
         "node": ">=6.5"
+      }
+    },
+    "node_modules/npm/node_modules/agent-base": {
+      "version": "7.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/npm/node_modules/aggregate-error": {
@@ -903,15 +906,12 @@
       }
     },
     "node_modules/npm/node_modules/ansi-styles": {
-      "version": "4.3.0",
+      "version": "6.2.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
@@ -930,14 +930,10 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/are-we-there-yet": {
-      "version": "4.0.1",
+      "version": "4.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^4.1.0"
-      },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
@@ -965,7 +961,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/bin-links": {
@@ -1018,7 +1013,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
@@ -1035,7 +1029,7 @@
       }
     },
     "node_modules/npm/node_modules/cacache": {
-      "version": "18.0.0",
+      "version": "18.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -1045,7 +1039,7 @@
         "glob": "^10.2.2",
         "lru-cache": "^10.0.1",
         "minipass": "^7.0.3",
-        "minipass-collect": "^1.0.2",
+        "minipass-collect": "^2.0.1",
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
         "p-map": "^4.0.0",
@@ -1079,7 +1073,7 @@
       }
     },
     "node_modules/npm/node_modules/ci-info": {
-      "version": "3.9.0",
+      "version": "4.0.0",
       "dev": true,
       "funding": [
         {
@@ -1094,15 +1088,15 @@
       }
     },
     "node_modules/npm/node_modules/cidr-regex": {
-      "version": "3.1.1",
+      "version": "4.0.3",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "ip-regex": "^4.1.0"
+        "ip-regex": "^5.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       }
     },
     "node_modules/npm/node_modules/clean-stack": {
@@ -1291,7 +1285,6 @@
     "node_modules/npm/node_modules/delegates": {
       "version": "1.0.0",
       "dev": true,
-      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/diff": {
@@ -1343,7 +1336,6 @@
     "node_modules/npm/node_modules/event-target-shim": {
       "version": "5.0.1",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -1352,7 +1344,6 @@
     "node_modules/npm/node_modules/events": {
       "version": "3.3.0",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
@@ -1402,10 +1393,13 @@
       }
     },
     "node_modules/npm/node_modules/function-bind": {
-      "version": "1.1.1",
+      "version": "1.1.2",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/npm/node_modules/gauge": {
       "version": "5.0.1",
@@ -1457,7 +1451,6 @@
     "node_modules/npm/node_modules/has": {
       "version": "1.0.3",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1"
@@ -1471,6 +1464,18 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC"
+    },
+    "node_modules/npm/node_modules/hasown": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/npm/node_modules/hosted-git-info": {
       "version": "7.0.1",
@@ -1489,6 +1494,32 @@
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/npm/node_modules/http-proxy-agent": {
+      "version": "7.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/npm/node_modules/https-proxy-agent": {
+      "version": "7.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/npm/node_modules/iconv-lite": {
       "version": "0.6.3",
@@ -1520,11 +1551,10 @@
           "url": "https://feross.org/support"
         }
       ],
-      "inBundle": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/npm/node_modules/ignore-walk": {
-      "version": "6.0.3",
+      "version": "6.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -1587,33 +1617,36 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/ip-regex": {
-      "version": "4.3.0",
+      "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/npm/node_modules/is-cidr": {
-      "version": "4.0.2",
+      "version": "5.0.3",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "cidr-regex": "^3.1.1"
+        "cidr-regex": "4.0.3"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       }
     },
     "node_modules/npm/node_modules/is-core-module": {
-      "version": "2.13.0",
+      "version": "2.13.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -1659,7 +1692,7 @@
       }
     },
     "node_modules/npm/node_modules/json-parse-even-better-errors": {
-      "version": "3.0.0",
+      "version": "3.0.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -1698,7 +1731,7 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/libnpmaccess": {
-      "version": "8.0.1",
+      "version": "8.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -1711,7 +1744,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "6.0.3",
+      "version": "6.0.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -1731,14 +1764,14 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "7.0.3",
+      "version": "7.0.7",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/arborist": "^7.2.1",
         "@npmcli/run-script": "^7.0.2",
-        "ci-info": "^3.7.1",
+        "ci-info": "^4.0.0",
         "npm-package-arg": "^11.0.1",
         "npmlog": "^7.0.1",
         "pacote": "^17.0.4",
@@ -1753,7 +1786,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "5.0.1",
+      "version": "5.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -1765,7 +1798,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmhook": {
-      "version": "10.0.0",
+      "version": "10.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -1778,7 +1811,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmorg": {
-      "version": "6.0.1",
+      "version": "6.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -1791,7 +1824,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "6.0.3",
+      "version": "6.0.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -1806,18 +1839,18 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpublish": {
-      "version": "9.0.1",
+      "version": "9.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "ci-info": "^3.6.1",
+        "ci-info": "^4.0.0",
         "normalize-package-data": "^6.0.0",
         "npm-package-arg": "^11.0.1",
         "npm-registry-fetch": "^16.0.0",
         "proc-log": "^3.0.0",
         "semver": "^7.3.7",
-        "sigstore": "^2.1.0",
+        "sigstore": "^2.2.0",
         "ssri": "^10.0.5"
       },
       "engines": {
@@ -1825,7 +1858,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmsearch": {
-      "version": "7.0.0",
+      "version": "7.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -1837,7 +1870,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmteam": {
-      "version": "6.0.0",
+      "version": "6.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -1850,7 +1883,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmversion": {
-      "version": "5.0.1",
+      "version": "5.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -1866,7 +1899,7 @@
       }
     },
     "node_modules/npm/node_modules/lru-cache": {
-      "version": "10.0.1",
+      "version": "10.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -1921,27 +1954,15 @@
       }
     },
     "node_modules/npm/node_modules/minipass-collect": {
-      "version": "1.0.2",
+      "version": "2.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "minipass": "^3.0.0"
+        "minipass": "^7.0.3"
       },
       "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-collect/node_modules/minipass": {
-      "version": "3.3.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/npm/node_modules/minipass-fetch": {
@@ -2228,12 +2249,12 @@
       }
     },
     "node_modules/npm/node_modules/npm-packlist": {
-      "version": "8.0.0",
+      "version": "8.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "ignore-walk": "^6.0.0"
+        "ignore-walk": "^6.0.4"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -2325,7 +2346,7 @@
       }
     },
     "node_modules/npm/node_modules/pacote": {
-      "version": "17.0.4",
+      "version": "17.0.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -2345,7 +2366,7 @@
         "promise-retry": "^2.0.1",
         "read-package-json": "^7.0.0",
         "read-package-json-fast": "^3.0.0",
-        "sigstore": "^2.0.0",
+        "sigstore": "^2.2.0",
         "ssri": "^10.0.0",
         "tar": "^6.1.11"
       },
@@ -2396,7 +2417,7 @@
       }
     },
     "node_modules/npm/node_modules/postcss-selector-parser": {
-      "version": "6.0.13",
+      "version": "6.0.15",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -2420,7 +2441,6 @@
     "node_modules/npm/node_modules/process": {
       "version": "0.11.10",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
@@ -2436,7 +2456,7 @@
       }
     },
     "node_modules/npm/node_modules/promise-call-limit": {
-      "version": "1.0.2",
+      "version": "3.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -2535,7 +2555,6 @@
     "node_modules/npm/node_modules/readable-stream": {
       "version": "4.4.2",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
@@ -2574,7 +2593,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/safer-buffer": {
@@ -2639,7 +2657,7 @@
       }
     },
     "node_modules/npm/node_modules/signal-exit": {
-      "version": "4.0.2",
+      "version": "4.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -2651,15 +2669,17 @@
       }
     },
     "node_modules/npm/node_modules/sigstore": {
-      "version": "2.1.0",
+      "version": "2.2.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@sigstore/bundle": "^2.1.0",
+        "@sigstore/bundle": "^2.1.1",
+        "@sigstore/core": "^0.2.0",
         "@sigstore/protobuf-specs": "^0.2.1",
-        "@sigstore/sign": "^2.1.0",
-        "@sigstore/tuf": "^2.1.0"
+        "@sigstore/sign": "^2.2.1",
+        "@sigstore/tuf": "^2.3.0",
+        "@sigstore/verify": "^0.1.0"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
@@ -2687,6 +2707,20 @@
       "engines": {
         "node": ">= 10.13.0",
         "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/socks-proxy-agent": {
+      "version": "8.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "^4.3.4",
+        "socks": "^2.7.1"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/npm/node_modules/spdx-correct": {
@@ -2736,7 +2770,6 @@
     "node_modules/npm/node_modules/string_decoder": {
       "version": "1.3.0",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -2880,7 +2913,7 @@
       }
     },
     "node_modules/npm/node_modules/tuf-js": {
-      "version": "2.1.0",
+      "version": "2.2.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3028,6 +3061,21 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/npm/node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
       "version": "6.0.1",
       "dev": true,
@@ -3038,18 +3086,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/emoji-regex": {

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
     "@types/react": "^18.0.14",
     "@types/react-dom": "^18.0.5",
     "@types/semver": "^7.3.10",
-    "npm": "^10.2.3",
+    "npm": "^10.4.0",
     "prettier": "^3.0.0",
     "typescript": "^5.2.2"
   },
-  "packageManager": "npm@10.2.3"
+  "packageManager": "npm@10.4.0"
 }

--- a/src/util/backend/db-postgres.ts
+++ b/src/util/backend/db-postgres.ts
@@ -35,10 +35,14 @@ export async function findOne(name: string, version: string) {
     return reply as PkgSize;
 }
 
-export async function insert(pkg: PkgSize) {
+export async function insert({ name, version, publishSize, installSize, publishFiles, installFiles }: PkgSize) {
     console.time('insert (postgres)');
     const reply = await sql`
-        INSERT INTO "packages" VALUES (${pkg.name}, ${pkg.version}, ${pkg.publishSize}, ${pkg.installSize}, ${pkg.publishFiles}, ${pkg.installFiles});
+        INSERT INTO "packages" 
+        VALUES (${name}, ${version}, ${publishSize}, ${installSize}, ${publishFiles}, ${installFiles})
+        ON CONFLICT (packages_pkey)
+        DO UPDATE SET "publishSize" = ${publishSize}, "installSize" = ${installSize}, "publishFiles" = ${publishFiles}, "installFiles" = ${installFiles}
+        ;
     `;
     console.timeEnd('insert (postgres)');
     return reply;

--- a/src/util/backend/db-postgres.ts
+++ b/src/util/backend/db-postgres.ts
@@ -35,12 +35,19 @@ export async function findOne(name: string, version: string) {
     return reply as PkgSize;
 }
 
-export async function insert({ name, version, publishSize, installSize, publishFiles, installFiles }: PkgSize) {
+export async function insert({
+    name,
+    version,
+    publishSize,
+    installSize,
+    publishFiles,
+    installFiles,
+}: PkgSize) {
     console.time('insert (postgres)');
     const reply = await sql`
         INSERT INTO "packages" 
         VALUES (${name}, ${version}, ${publishSize}, ${installSize}, ${publishFiles}, ${installFiles})
-        ON CONFLICT (packages_pkey)
+        ON CONFLICT ("name", "version")
         DO UPDATE SET "publishSize" = ${publishSize}, "installSize" = ${installSize}, "publishFiles" = ${publishFiles}, "installFiles" = ${installFiles}
         ;
     `;


### PR DESCRIPTION
Bumps to [`npm@10.4.0`](https://github.com/npm/cli/releases/tag/v10.4.0) which adds a fix for [arborist](https://github.com/npm/cli/pull/7126) which will avoid installing multiple libc binaries and [correctly select glibc vs musl](https://github.com/npm/rfcs/issues/438) from the optionalDependencies.