### PR TITLE
fix: switch npm.anvaka.com to npmgraph.js.org

### DIFF
--- a/src/components/LinkedLogos.tsx
+++ b/src/components/LinkedLogos.tsx
@@ -65,8 +65,8 @@ export default (props: Props) => {
                 title="graph"
                 href={
                     isLatest
-                        ? `https://npm.anvaka.com/#/view/2d/${escape(escape(name))}`
-                        : `https://npm.anvaka.com/#/view/2d/${escape(escape(name))}/${version}`
+                        ? `https://npmgraph.js.org/?q=${name}`
+                        : `https://npmgraph.js.org/?q=${name}@${version}`
                 }
             />
         </>


### PR DESCRIPTION
This project is actively maintained so more likely to get a size feature to land.

### Related
- https://github.com/anvaka/npmgraph.an/pull/27
- https://github.com/npmgraph/npmgraph/issues/132