### PR TITLE
fix: add missing start_url to webmanifest

### DIFF
--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -13,6 +13,7 @@
             "type": "image/png"
         }
     ],
+    "start_url": "/?utm_source=a2hs",
     "theme_color": "#333333",
     "background_color": "#333333",
     "display": "standalone"


### PR DESCRIPTION
It seems that right now without `start_url` the PWA is not installable. This should hopefully fix the issue.