### PR TITLE
chore(config): remove memory config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,6 @@
 {
     "functions": {
         "api/**": {
-            "memory": 2048,
             "maxDuration": 30
         }
     },


### PR DESCRIPTION
This should be configured in the dashboard instead

https://vercel.com/changelog/faster-defaults-for-vercel-function-cpu-and-memory