### PR TITLE
fix: more aggressive rate limit

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -40,7 +40,7 @@ export async function handler(req: IncomingMessage, res: ServerResponse) {
         userAgent.startsWith('got')
     ) {
         botCount++;
-        if (botCount % 10 === 0) {
+        if (botCount % 2 === 0) {
             res.statusCode = 429;
             res.end(
                 'Too many requests from unknown user-agent. See https://github.com/styfle/packagephobia/blob/main/API.md',


### PR DESCRIPTION
Way too many requests coming from unknown clients. This will make sure clients identify themselves with a user-agent.