### PR TITLE
docs: add new user to API.md

### DIFF
--- a/API.md
+++ b/API.md
@@ -13,6 +13,7 @@ Current websites using this API:
 - https://npm.taobao.org
 - https://bestofjs.org
 - https://socket.dev
+- picocolors
 
 ## Endpoints
 


### PR DESCRIPTION
Hi 👋

This PR adds [picocolors](https://github.com/alexeyraspopov/picocolors) to the list

As you can see, picocolors using API from packagephobia but get `Forbidden` error because of API block policy.

And don't worry. I set appropriate user-agent header too [here](https://github.com/alexeyraspopov/picocolors/pull/76).

<img width="755" alt="image" src="https://github.com/user-attachments/assets/4043866a-9d9f-47bb-8b85-0194e139ded8">

