### PR TITLE
docs(API): update usename

### DIFF
--- a/API.md
+++ b/API.md
@@ -13,7 +13,7 @@ Current websites using this API:
 - https://npm.taobao.org
 - https://bestofjs.org
 - https://socket.dev
-- picocolors-size-benchmark
+- [picocolors-size-benchmark](https://github.com/alexeyraspopov/picocolors/pull/76)
 
 ## Endpoints
 

--- a/API.md
+++ b/API.md
@@ -13,6 +13,7 @@ Current websites using this API:
 - https://npm.taobao.org
 - https://bestofjs.org
 - https://socket.dev
+- picocolors
 
 ## Endpoints
 

--- a/API.md
+++ b/API.md
@@ -13,7 +13,7 @@ Current websites using this API:
 - https://npm.taobao.org
 - https://bestofjs.org
 - https://socket.dev
-- picocolors
+- picocolors-size-benchmark
 
 ## Endpoints
 


### PR DESCRIPTION
as-is : picocolors
to-be : picocolors-size-benchmark

Changed name since picocolors use API call only when size benchmark. 

Thanks!

related : https://github.com/alexeyraspopov/picocolors/pull/76