### PR TITLE
fix: reduce timeout to 25 seconds

### DIFF
--- a/src/util/backend/npm-wrapper.ts
+++ b/src/util/backend/npm-wrapper.ts
@@ -6,9 +6,16 @@ import { promisify } from 'util';
 const execFileAysnc = promisify(execFile);
 const npm = join(require.resolve('npm'), '../bin/npm-cli.js');
 
-export async function npmInstall(cwd: string, cacheDir: string, name: string, version: string) {
+export async function npmInstall(
+    cwd: string,
+    cacheDir: string,
+    name: string,
+    version: string,
+    signal: AbortSignal,
+) {
     const result = await execFileAysnc(npm, ['i', `${name}@${version}`], {
         cwd,
+        signal,
         env: {
             ...process.env,
             // See https://docs.npmjs.com/cli/v10/commands/npm#configuration


### PR DESCRIPTION
- Related to https://github.com/styfle/packagephobia/issues/1067

We give the npm package 25 seconds and that leaves 5 seconds to cleanup when we fail for a total of 30 seconds.