### PR TITLE
fix: add `nofollow` attribute to error logs link

### DIFF
--- a/src/pages/500.tsx
+++ b/src/pages/500.tsx
@@ -23,6 +23,7 @@ export default ({ reqId }: { reqId: string }) => (
                 </p>
                 <p>
                     <a
+                        rel="nofollow"
                         href={`https://vercel.com/packagephobia/packagephobia/logs?requestIds=${reqId}`}
                     >
                         View Logs


### PR DESCRIPTION
This should prevent google from trying to crawl a private link to the error logs.

The proper solution is to hide this link when the viewer is not a member of the packagephobia team since humans get confused by this too, but I am too lazy and the error page is an exception, not a happy path 🤷 