### PR TITLE
chore: ignore `.env*.local`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 node_modules
 dist
 .DS_Store
-.env
+.env*.local
 .next
 pages/*.js
 src/*.js


### PR DESCRIPTION
This makes sure to ignore all env files